### PR TITLE
Add release notes for 0.292

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.292
     Release-0.291 [2025-01-27] <release/release-0.291>
     Release-0.290 [2024-11-01] <release/release-0.290>
     Release-0.289 [2024-08-23] <release/release-0.289>

--- a/presto-docs/src/main/sphinx/release/release-0.292.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.292.rst
@@ -1,0 +1,100 @@
+=============
+Release 0.292
+=============
+
+**Highlights**
+==============
+
+**Details**
+===========
+
+General Changes
+_______________
+* Fix Hive ``UUID`` type parsing. `#24538 <https://github.com/prestodb/presto/pull/24538>`_
+* Fix Iceberg date column filtering. `#24583 <https://github.com/prestodb/presto/pull/24583>`_
+* Fix OSS connectors affected by changes. `#24528 <https://github.com/prestodb/presto/pull/24528>`_
+* Fix a security bug when ``check_access_control_for_utlized_columns`` is true for queries that uses a ``WITH`` clause. Previously we would sometime not check permissions for certain columns that were used in the query.  Now we will always check permissions for all columns used in the query. There are some corner cases for CTEs with the same name where we may check more columns than are used or fall back to checking all columns referenced in the query. `#24647 <https://github.com/prestodb/presto/pull/24647>`_
+* Fix silently returning incorrect results when trying to construct a TimestampWithTimeZone from a value that has a unix timestamp that is too large/small. `#24674 <https://github.com/prestodb/presto/pull/24674>`_
+* Improve error handling of ``INTERVAL DAY``, ``INTERVAL HOUR``, and ``INTERVAL SECOND`` operators when experiencing overflows. :pr:`24353`. `#24353 <https://github.com/prestodb/presto/pull/24353>`_
+* Improve scheduling by using long instead of DataSize for critical path. `#24582 <https://github.com/prestodb/presto/pull/24582>`_
+* Add :doc:`../troubleshoot` topic to the Presto documentation. `#24601 <https://github.com/prestodb/presto/pull/24601>`_
+* Add Arrow Flight connector :pr:`24427`. `#24427 <https://github.com/prestodb/presto/pull/24427>`_
+* Add a MySQL-compatible function ``bit_length`` that returns the count of bits for the given string. `#24531 <https://github.com/prestodb/presto/pull/24531>`_
+* Add configuration property ``exclude-invalid-worker-session-properties``. `#23968 <https://github.com/prestodb/presto/pull/23968>`_
+* Add documentation for file-based Hive metastore to :doc:`/installation/deployment`. `#24620 <https://github.com/prestodb/presto/pull/24620>`_
+* Add documentation for the :doc:`/connector/base-arrow-flight`  :pr:`24427`. `#24427 <https://github.com/prestodb/presto/pull/24427>`_
+* Add pagesink for DELETES to support future use. `#24528 <https://github.com/prestodb/presto/pull/24528>`_
+* Add serialization for new types. `#24528 <https://github.com/prestodb/presto/pull/24528>`_
+* Add support to build Presto with JDK 17. `#24677 <https://github.com/prestodb/presto/pull/24677>`_
+* Added a new optimizer rule to add exchanges below a combination of partial aggregation+ GroupId . Enabled with the boolean session property `enable_forced_exchange_below_group_id`. `#24047 <https://github.com/prestodb/presto/pull/24047>`_
+* Replace depreciated ``dagre-d3`` with ``dagre-d3-es`` in response to a high severity vulnerability [WS-2022-0322](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2482). `#24167 <https://github.com/prestodb/presto/pull/24167>`_
+* Enable file-based hive metastore to use HDFS/S3 location as warehouse dir. `#24660 <https://github.com/prestodb/presto/pull/24660>`_
+* Enable node pool type specification when reporting to the coordinator from a C++ worker. `#24569 <https://github.com/prestodb/presto/pull/24569>`_
+* Make the number of task event loop configurable via a configuration file. `#24565 <https://github.com/prestodb/presto/pull/24565>`_
+* Refactored org.apache.logging.log4j:log4j-api out if root POM. `#24605 <https://github.com/prestodb/presto/pull/24605>`_
+* Refactored org.apache.logging.log4j:log4j-core out of root POM. `#24605 <https://github.com/prestodb/presto/pull/24605>`_
+* Update beginDelete to return the new types, and finishDelete to accept the new types. `#24528 <https://github.com/prestodb/presto/pull/24528>`_
+* Upgrade bootstrap to version 5. `#24167 <https://github.com/prestodb/presto/pull/24167>`_
+* Upgrade jQuery to version 3.7.1. `#24167 <https://github.com/prestodb/presto/pull/24167>`_
+* Upgrade libthrift to 0.14.1 in response to `CVE-2020-13949 <https://github.com/advisories/GHSA-g2fg-mr77-6vrm>`_. `#24462 <https://github.com/prestodb/presto/pull/24462>`_
+* Upgrade netty dependencies to version 4.1.115.Final in response to `CVE-2024-47535 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-47535>`. `#24586 <https://github.com/prestodb/presto/pull/24586>`_
+* Upgraded org.apache.logging.log4j:log4j-api from 2.17.1 to 2.24.3 in response to `CVE-2024-47554 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-47554>`. `#24507 <https://github.com/prestodb/presto/pull/24507>`_
+* Upgraded org.apache.logging.log4j:log4j-core from 2.17.1 to 2.24.3 in response to `CVE-2024-47554<https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-47554>`. `#24507 <https://github.com/prestodb/presto/pull/24507>`_
+
+Security Changes
+________________
+* Upgrade commons-text  to 1.13.0 in response to `CVE-2024-47554<https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-47554>`_. `#24467 <https://github.com/prestodb/presto/pull/24467>`_
+* Upgrade org.apache.ratis  to 3.1.3 in response to `CVE-2020-15250<https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15250>`_. `#24496 <https://github.com/prestodb/presto/pull/24496>`_
+
+Hive Connector Changes
+______________________
+* Fix Parquet read failing for nested Decimal types :pr:`24440`. `#24440 <https://github.com/prestodb/presto/pull/24440>`_
+* Fix getting views for Hive metastore 2.3+. `#24466 <https://github.com/prestodb/presto/pull/24466>`_
+* Add session property ``hive.stats_based_filter_reorder_disabled`` for disabling reader stats based filter reordering. `#24630 <https://github.com/prestodb/presto/pull/24630>`_
+* Replaced return type of beginDelete. `#24528 <https://github.com/prestodb/presto/pull/24528>`_
+* Rename session property ``hive.stats_based_filter_reorder_disabled`` to ``hive.native_stats_based_filter_reorder_disabled``. `#24637 <https://github.com/prestodb/presto/pull/24637>`_
+
+Iceberg Connector Changes
+_________________________
+* Fix IcebergTableHandle implementation to work with new types used in begin/finishDelete. `#24528 <https://github.com/prestodb/presto/pull/24528>`_
+* Fix bug with missing statistics when the statistics file cache has a partial miss. `#24480 <https://github.com/prestodb/presto/pull/24480>`_
+* Add ``read.split.target-size`` table property. `#24417 <https://github.com/prestodb/presto/pull/24417>`_
+* Add ``target_split_size_bytes`` session property. `#24417 <https://github.com/prestodb/presto/pull/24417>`_
+* Add a dedicated subclass of `FileHiveMetastore` for Iceberg connector to capture and isolate the differences in behavior. `#24573 <https://github.com/prestodb/presto/pull/24573>`_
+* Add connector configuration property ``iceberg.catalog.hadoop.warehouse.datadir`` for Hadoop catalog to specify root data write path for its new created tables. `#24397 <https://github.com/prestodb/presto/pull/24397>`_
+* Add logic to iceberg type converter for timestamp with timezone :pr:`23534`. `#23534 <https://github.com/prestodb/presto/pull/23534>`_
+* Add manifest file caching for deployments which use the Hive metastore. `#24481 <https://github.com/prestodb/presto/pull/24481>`_
+* Add support for the ``hive.affinity-scheduling-file-section-size`` configuration property and ``affinity_scheduling_file_section_size`` session property. `#24598 <https://github.com/prestodb/presto/pull/24598>`_
+* Add support of ``renaming table`` for Iceberg connector when configured with ``HIVE`` file catalog. `#24312 <https://github.com/prestodb/presto/pull/24312>`_
+* Add table properties ``write.data.path`` to specify independent data write paths for Iceberg tables. `#24397 <https://github.com/prestodb/presto/pull/24397>`_
+* Enable manifest caching by default. `#24481 <https://github.com/prestodb/presto/pull/24481>`_
+* Support for Iceberg table sort orders. Tables can be created to add a list of `sorted_by` columns which will be used to order files written to the table. `#21977 <https://github.com/prestodb/presto/pull/21977>`_
+
+Kudu Connector Changes
+______________________
+* Replaced return type of beginDelete. `#24528 <https://github.com/prestodb/presto/pull/24528>`_
+
+Tpc-ds Connector Changes
+________________________
+* Add config property ``tpcds.use-varchar-type`` to allow toggling of char columns to varchar columns. `#24406 <https://github.com/prestodb/presto/pull/24406>`_
+
+SPI Changes
+___________
+* Add ConnectorSession as an argument to PlanChecker.validate and PlanChecker.validateFragment. `#24557 <https://github.com/prestodb/presto/pull/24557>`_
+* Add DeleteTableHandle support these changes in Metadata. `#24528 <https://github.com/prestodb/presto/pull/24528>`_
+* Add ``CoordinatorPlugin#getExpressionOptimizerFactories`` to customize expression evaluation in the Presto coordinator. :pr:`24144`. `#24144 <https://github.com/prestodb/presto/pull/24144>`_
+* Add a separate ConnectorDeleteTableHandle interface for `ConnectorMetadata.beginDelete` and `ConnectorMetadata.finishDelete`, replacing the previous usage of ConnectorTableHandle. `#24528 <https://github.com/prestodb/presto/pull/24528>`_
+* Move IndexSourceNode to the SPI. `#24678 <https://github.com/prestodb/presto/pull/24678>`_
+
+Elastic Search Changes
+______________________
+* Improve cryptographic protocol in response to `java:S4423 <https://sonarqube.ow2.org/coding_rules?open=java%3AS4423&rule_key=java%3AS4423>`_. `#24474 <https://github.com/prestodb/presto/pull/24474>`_
+
+Iceberg Changes
+_______________
+* Iceberg connector support for ``UPDATE`` SQL statements. `#24281 <https://github.com/prestodb/presto/pull/24281>`_
+
+**Credits**
+===========
+
+Abe Varghese, Amit Dutta, Anant Aneja, Andrii Rosa, Bryan Cutler, Christian Zentgraf, Deepak Majeti, Denodo Research Labs, Dilli-Babu-Godari, Elbin Pallimalil, Eric Liu, Ge Gao, Jalpreet Singh Nanda, Joe Giardino, Ke, Kevin Tang, Kevin Wilfong, Krishna Pai, Mahadevuni Naveen Kumar, Mariam AlMesfer, Minhan Cao, Natasha Sehgal, Nicholas Ormrod, Nidhin Varghese, Nikhil Collooru, Patrick Sullivan, Pradeep Vaka, Pramod Satya, Pratik Joseph Dabre, Rebecca Schlussel, Reetika Agrawal, Sagar Sumit, Sayari Mukherjee, Sergey Pershin, Shahim Sharafudeen, Shakyan Kushwaha, Shang Ma, Shelton Cai, Steve Burnett, Sumi Mathew, Swapnil, Timothy Meehan, XiaoDu, Xiaoxuan Meng, Yihong Wang, Yihong Wang, Ying, Yuanda (Yenda) Li, Zac Blanco, Zac Wen, aditi-pandit, ajay-kharat, auden-woolfson, dnskr, inf, jay.narale, librian415, namya28, shenh062326, unidevel, vhsu14, wangd, wypb


### PR DESCRIPTION
# Missing Release Notes
## Amit Dutta
- [ ] https://github.com/prestodb/presto/pull/24470 [native] Advance velox, fix build and unit test. (Merged by: Amit Dutta)

## Deepak Majeti
- [ ] https://github.com/prestodb/presto/pull/24642 [native] Default task.max-drivers-per-task to hardware concurrency (Merged by: Deepak Majeti)

## Eric Liu
- [ ] https://github.com/prestodb/presto/pull/24533 Improve boostrap log to expose the wrong classLoader (Merged by: Rebecca Schlussel)

## Joe Giardino
- [ ] https://github.com/prestodb/presto/pull/24625 [native] Fix includes (Merged by: Swapnil)

## Mariam AlMesfer
- [ ] https://github.com/prestodb/presto/pull/23796 Security Fix: Okio CVE-2023-3635 + OkHttp Jar Update (Merged by: Timothy Meehan)

## Minhan Cao
- [ ] https://github.com/prestodb/presto/pull/24623 [docs] Add documentation for cache configuration properties (Merged by: Steve Burnett)
- [ ] https://github.com/prestodb/presto/pull/24149 [native] Add LinuxMemoryChecker check/warning to ensure system-mem-limit-gb is reasonably set (Merged by: Christian Zentgraf)
- [ ] https://github.com/prestodb/presto/pull/24607 [docs] Add documentation to note "-gb" Prestissimo Configs are using GiB units and not gB units (Merged by: Steve Burnett)

## Pradeep Vaka
- [ ] https://github.com/prestodb/presto/pull/24503 [native]: Add operator override for xxhash64, combine_hash internal functions (Merged by: Aditi Pandit)

## Pratik Joseph Dabre
- [ ] https://github.com/prestodb/presto/pull/23358 Add a native function namespace manager (Merged by: Pratik Joseph Dabre)

## Shahim Sharafudeen
- [ ] https://github.com/prestodb/presto/pull/24631 Upgrade json-smart version to 2.5.2 in response to CVE-2024-57699 (Merged by: Ying)

## Shakyan Kushwaha
- [ ] https://github.com/prestodb/presto/pull/24455 [native] Allow options for wget and tar commands during setup (Merged by: Christian Zentgraf)

## Shang Ma
- [ ] https://github.com/prestodb/presto/pull/24668 Put event loop behind a toggle (Merged by: Shang Ma)
- [ ] https://github.com/prestodb/presto/pull/24414 Optimize how we merge multiple operatorStats (Merged by: Andrii Rosa)

## namya28
- [ ] https://github.com/prestodb/presto/pull/24438 Upgrade accumulo to 1.10.1 to fix CVE-2020-17533 (Merged by: Timothy Meehan)
- [ ] https://github.com/prestodb/presto/pull/24461 Upgrading hive-dwrf version to 0.8.7 which involved upgrading snappy version to 0.5 to fix CVE-2024-36124 (Merged by: Timothy Meehan)

## unidevel
- [ ] c6948d7c79e0387ef611846fcec16da03f9bb054 Add prepare release action
- [ ] 305890672fe63af08fdfe07b11c013b45f5ea513 Update release-notes script
- [ ] 469d7b1232b16527f0e7b2e0d412f22ad12a9652 Refactor presto release actions

## wypb
- [ ] https://github.com/prestodb/presto/pull/23037 [native] Add support for ORC reader (Merged by: Aditi Pandit)

# Extracted Release Notes
- #21977 (Author: Nidhin Varghese): Add Support for Iceberg table sort orders
  - Support for Iceberg table sort orders. Tables can be created to add a list of `sorted_by` columns which will be used to order files written to the table.
- #23534 (Author: auden-woolfson): Fix timestamp with timezone mapping in iceberg type converter
  - Add logic to iceberg type converter for timestamp with timezone :pr:`23534`.
- #23968 (Author: Pratik Joseph Dabre): [native] Add a config property for excluding invalid worker session properties
  - Add configuration property ``exclude-invalid-worker-session-properties``.
- #24047 (Author: Anant Aneja): Add Exchange before GroupId to improve Partial Aggregation
  - Added a new optimizer rule to add exchanges below a combination of partial aggregation+ GroupId . Enabled with the boolean session property `enable_forced_exchange_below_group_id`.
- #24144 (Author: Timothy Meehan): Add SPI for delegating row expression optimizer
  - Add ``CoordinatorPlugin#getExpressionOptimizerFactories`` to customize expression evaluation in the Presto coordinator. :pr:`24144`.
- #24167 (Author: Yihong Wang): presto-ui forwardfit
  - Upgrade bootstrap to version 5.
  - Upgrade jQuery to version 3.7.1.
  - Replace depreciated ``dagre-d3`` with ``dagre-d3-es`` in response to a high severity vulnerability [WS-2022-0322](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2482).
- #24281 (Author: Zac Blanco): Add UPDATE support for Iceberg
  - Iceberg connector support for ``UPDATE`` SQL statements.
- #24312 (Author: wangd): [Iceberg]Support renaming table on hive file catalog
  - Add support of ``renaming table`` for Iceberg connector when configured with ``HIVE`` file catalog.
- #24353 (Author: librian415): [Presto-Main] Add long overflow checks for IntervalDayTime
  - Improve error handling of ``INTERVAL DAY``, ``INTERVAL HOUR``, and ``INTERVAL SECOND`` operators when experiencing overflows. :pr:`24353`.
- #24397 (Author: wangd): [Iceberg]Support setting warehouse data directory for Hadoop catalog
  - Add table properties ``write.data.path`` to specify independent data write paths for Iceberg tables.
  - Add connector configuration property ``iceberg.catalog.hadoop.warehouse.datadir`` for Hadoop catalog to specify root data write path for its new created tables.
- #24406 (Author: Pratik Joseph Dabre): Add a config flag `tpcds.use-varchar-type` in Presto - Java TPC-DS Connector
  - Add config property ``tpcds.use-varchar-type`` to allow toggling of char columns to varchar columns.
- #24417 (Author: Zac Blanco): [Iceberg] Add table and session property for split size
  - Add ``target_split_size_bytes`` session property.
  - Add ``read.split.target-size`` table property.
- #24427 (Author: Bryan Cutler): Arrow Flight Connector Template
  - Add Arrow Flight connector :pr:`24427`.
  - Add documentation for the :doc:`/connector/base-arrow-flight`  :pr:`24427`.
- #24440 (Author: Denodo Research Labs): Avoid batch reading of nested decimals as this reader is not implemented
  - Fix Parquet read failing for nested Decimal types :pr:`24440`.
- #24462 (Author: Denodo Research Labs): Upgrade libthrift to 0.14.1 due CVE-2020-13949
  - Upgrade libthrift to 0.14.1 in response to `CVE-2020-13949 <https://github.com/advisories/GHSA-g2fg-mr77-6vrm>`_.
- #24466 (Author: Sayari Mukherjee): Fix getting views for Hive metastore 2.3+ 
  - Fix getting views for Hive metastore 2.3+.
- #24467 (Author: Sumi Mathew): Upgrade the jar org.apache.commons:commons-text:1.10.0 to 1.13.0
  - Upgrade commons-text  to 1.13.0 in response to `CVE-2024-47554<https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-47554>`_.
- #24474 (Author: Shahim Sharafudeen): Update security protocol to TLS
  - Improve cryptographic protocol in response to `java:S4423 <https://sonarqube.ow2.org/coding_rules?open=java%3AS4423&rule_key=java%3AS4423>`_.
- #24480 (Author: Zac Blanco): [Iceberg] Fix bugs in Iceberg statistics caching
  - Fix bug with missing statistics when the statistics file cache has a partial miss.
- #24481 (Author: Zac Blanco): [Iceberg] Add manifest file caching for HMS-based deployments
  - Add manifest file caching for deployments which use the Hive metastore.
  - Enable manifest caching by default.
- #24496 (Author: Sumi Mathew): Upgrade org.apache.ratis dependency to address CVE-2020-15250
  - Upgrade org.apache.ratis  to 3.1.3 in response to `CVE-2020-15250<https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15250>`_.
- #24507 (Author: Dilli-Babu-Godari): Upgrade org.apache.logging.log4j:log4j-core and log4j-api libraries
  - Upgraded org.apache.logging.log4j:log4j-core from 2.17.1 to 2.24.3 in response to `CVE-2024-47554<https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-47554>`.
  - Upgraded org.apache.logging.log4j:log4j-api from 2.17.1 to 2.24.3 in response to `CVE-2024-47554 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-47554>`.
- #24528 (Author: Shelton Cai): Update begin delete
  - Fix OSS connectors affected by changes.
  - Add serialization for new types.
  - Add pagesink for DELETES to support future use.
  - Update beginDelete to return the new types, and finishDelete to accept the new types.
  - Add a separate ConnectorDeleteTableHandle interface for `ConnectorMetadata.beginDelete` and `ConnectorMetadata.finishDelete`, replacing the previous usage of ConnectorTableHandle.
  - Add DeleteTableHandle support these changes in Metadata.
  - Replaced return type of beginDelete.
  - Fix IcebergTableHandle implementation to work with new types used in begin/finishDelete.
  - Replaced return type of beginDelete.
- #24531 (Author: shenh062326): add mysql compatible function bit_length
  - Add a MySQL-compatible function ``bit_length`` that returns the count of bits for the given string.
- #24538 (Author: ajay-kharat): fixed hive view uuid type parsing
  - Fix Hive ``UUID`` type parsing.
- #24557 (Author: Rebecca Schlussel): Plan checker sessionPass ConnectorSession to PlanChecker
  - Add ConnectorSession as an argument to PlanChecker.validate and PlanChecker.validateFragment.
- #24565 (Author: Shang Ma): Make the number of task event loop configurable
  - Make the number of task event loop configurable via a configuration file.
- #24569 (Author: jay.narale): [native] Enable node pool type specification when reporting to the coordinator from a C++ worker 
  - Enable node pool type specification when reporting to the coordinator from a C++ worker.
- #24573 (Author: wangd): Subclass `FileHiveMetastore` for Iceberg connector
  - Add a dedicated subclass of `FileHiveMetastore` for Iceberg connector to capture and isolate the differences in behavior.
- #24582 (Author: Shang Ma): Change from DataSize to long to remove unnecessary data creation
  - Improve scheduling by using long instead of DataSize for critical path.
- #24583 (Author: Mahadevuni Naveen Kumar): [native] fix(iceberg): Date partition value parse issue
  - Fix Iceberg date column filtering.
- #24586 (Author: inf): Upgrade netty version to 4.1.118.Final
  - Upgrade netty dependencies to version 4.1.115.Final in response to `CVE-2024-47535 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-47535>`.
- #24598 (Author: Zac Blanco): [Iceberg] Enable affinity scheduling on file sections
  - Add support for the ``hive.affinity-scheduling-file-section-size`` configuration property and ``affinity_scheduling_file_section_size`` session property.
- #24601 (Author: Steve Burnett): [docs] Add Troubleshooting topic to documentation
  - Add :doc:`../troubleshoot` topic to the Presto documentation.
- #24605 (Author: Dilli-Babu-Godari): Refactor log4j-core and log4j-api dependencies out of root POM
  - Refactored org.apache.logging.log4j:log4j-core out of root POM.
  - Refactored org.apache.logging.log4j:log4j-api out if root POM.
- #24620 (Author: Steve Burnett): [docs] Move file-based metastore doc to installation/deployment.rst
  - Add documentation for file-based Hive metastore to :doc:`/installation/deployment`.
- #24630 (Author: Ke): Add hive session property to disable stats based filter reordering
  - Add session property ``hive.stats_based_filter_reorder_disabled`` for disabling reader stats based filter reordering.
- #24637 (Author: Ke): Add native prefix to hive session property
  - Rename session property ``hive.stats_based_filter_reorder_disabled`` to ``hive.native_stats_based_filter_reorder_disabled``.
- #24647 (Author: Rebecca Schlussel): Fix check_access_control_on_utilized_columns_only for CTE
  - Fix a security bug when ``check_access_control_for_utlized_columns`` is true for queries that uses a ``WITH`` clause. Previously we would sometime not check permissions for certain columns that were used in the query.  Now we will always check permissions for all columns used in the query. There are some corner cases for CTEs with the same name where we may check more columns than are used or fall back to checking all columns referenced in the query.
- #24660 (Author: wangd): Support HDFS and S3 path as warehouse directory for Hive file catalog
  - Enable file-based hive metastore to use HDFS/S3 location as warehouse dir.
- #24674 (Author: Kevin Wilfong): Fix silent overflow in DateTimeEncoding.pack
  - Fix silently returning incorrect results when trying to construct a TimestampWithTimeZone from a value that has a unix timestamp that is too large/small.
- #24677 (Author: Anant Aneja): Upgrade build to be compatible with JDK17
  - Add support to build Presto with JDK 17.
- #24678 (Author: Rebecca Schlussel): Move IndexSourceNode to the SPI
  - Move IndexSourceNode to the SPI.

# All Commits
- c6948d7c79e0387ef611846fcec16da03f9bb054 Add prepare release action (unidevel)
- 305890672fe63af08fdfe07b11c013b45f5ea513 Update release-notes script (unidevel)
- 469d7b1232b16527f0e7b2e0d412f22ad12a9652 Refactor presto release actions (unidevel)
- d05ee8faed84028f54ff811069e1eff1642925d9 [native] Advance velox. (Amit Dutta)
- a3843f67e0a81148c42a0acbba6547723409174d Add JDK 17 build support (Anant Aneja)
- ee6e83da59f75267c097772ce4b07ad719bb4f2e Upgrade Kafka version to 3.9.0 (Anant Aneja)
- 5d669590acbf80c05c41127a9cb340ac67edeba2 Add manifest caching to iceberg connector (Zac Blanco)
- 95845fb16dee717756e2e6415923f67395c80fe8 Fix check_access_control_on_utilized_columns_only for CTE (Rebecca Schlussel)
- 144105ddee28f688f1e3f2389d1c0ee5ff4d790a Upgrade sphinx to 8.2.1 and sphinx-immaterial to 0.13.0 (dnskr)
- d53d8e4fe26705e15568fcb866cbbb244c7b6391 [native] remove native prefix for native connector session property (Ke)
- 348e991f8292493aff78400d413d7d007daa489f Support HDFS and S3 path as warehouse directory for Hive file metastore (wangd)
- 9d46add27d5ad5baf795f13b315f601db9c80764 Fix silent overflow in DateTimeEncoding.pack (Kevin Wilfong)
- 6ee450c91617c6dd4f00dc17279cc601588003b1 Revert DataSize change for public-facing API (#24682) (Shang Ma)
- c29b385e57b6d044f438af1c720deab1998c537c Support Hudi merged view file slices for partition path updates without compaction (Sagar Sumit)
- cb73e994dfb73c04186411bfd41671716a02e09b Upgrade netty version to 4.1.118.Final to resolve CVE-2025-25193 (inf)
- 6d2364122f5cd4aff66142806f051a92913e2f94 Convert DataSize for presto-spark (Shang Ma)
- 28da88d2decdc32d0ee287b34ec2ad57f4602278 Convert DataSize for tests (Shang Ma)
- 0711cfa11af41ab26ce807a4c28d633895313c67 Convert DataSize for other files in presto-main (Shang Ma)
- 369deb735194f13c4e1287ed0b2fe5f608b160ca Convert DataSize for operator (Shang Ma)
- f6049e19ef736539e81cf4db0d5b95e1a07d3ea1 Convert DataSize for execution (Shang Ma)
- 7458b526d04a29552a5ddde217442b78c4c22e2c Convert DataSize for APIs (Shang Ma)
- 1623acc2f21b7a3a6fd3ef35bff6d8e84b9aee1a Convert DataSize for cpp worker (Shang Ma)
- d930d6999194e8c7f5741ff6793f4cf8adde0fd3 Convert DataSize for UI (Shang Ma)
- 7537e2a8dc9a58fef95212016778874325cbd425 Upgrade json-smart version to 2.5.2 in response to CVE-2024-57699 (Shahim Sharafudeen)
- 5b7748d5f5bebf96874dd8288fdfdb8f2dc15b96 Upgrade asm dependencies (Shahim Sharafudeen)
- 29837efa3a53ec45121ca104b747871e9d14c08b Move IndexSourceNode to the SPI (Rebecca Schlussel)
- e2fdc663de0e032581e569942c86788818f4dda7 Put event loop behind a toggle (#24668) (Shang Ma)
- 2d08ffbc30a686d582a0faad11ac7c37b7d2c473 [native] Advance velox. (Amit Dutta)
- cc35085053c6bf97187ba2a2a2bc475582141e63 Fix the dropdown menu style in WorkerTrhead (Yihong Wang)
- 55a935b21b58fcc544f8d15e63d7f0c3886a6ab4 Refactor log4j-core and log4j-api dependencies out of root POM (Dilli-Babu-Godari)
- 3c8d5efd941de1d04491bddc8f00e95139a5859a Remove not working command from README.md (unidevel)
- 33f437131cb338cc86872eef80e46c6c705b4171 Fix the lint errors (unidevel)
- 79ae08678c27568617697378a7a57f5317ddf0c4 Enable welcome page for UI path /ui/dev (unidevel)
- 3a162d5678ac854083f2ac2da1fa6e4d10c106a1 Add separate build/serve command for query_viewer_spa page (unidevel)
- 64c0e38fb4cc64200018ab47f408b43033c3882e Record presto exchange source request duration and num of retries (Ke)
- 74c041194e751b9e0e5f5d33a501426a35f6b7e4 Changed delta connector API in documentation (Hazmi)
- 7515e42f72babd3864eb54142f3adbc6fbc8bb66 Move velox ahead and fix tests. (Krishna Pai)
- 5e1f28f0a3046f2dd64cbe0c5f639b862b1df02a Fix the links on the doc page for the 0.291 release (dnskr)
- bd01f3db0b497ca40dd98202c94bcaa1c7b0cc78 Add documentation for cache configuration properties (Minhan Cao)
- 1d58bca069f17155d5082baf53c50c1d4f35b793 Align format for section headers in the documentation (dnskr)
- ba3230f09a290a164795b59e3b511e5528447ecd Add links from lakehouse connector docs to file-based metastore (Steve Burnett)
- 9d1cc51c0228ef9b387f7a2e5f8577be4a1718b7 [native] Advance velox. (Amit Dutta)
- 27469d06391167c950f91320be392f8cf9b562c2 Add registerProperty back for fbcode usage (#24653) (vhsu14)
- 90295926f398232d49a49c7e05b7014830ce872e [Iceberg] rename "target_split_size" to "target_split_size_bytes" (Zac Blanco)
- f6c97505e1374e6ba064dcbfea32e5c1cbd343be [native] Default task.max-drivers-per-task to hardware concurrency (Deepak Majeti)
- ed8584fc1a524b8a73fd9f15a5e634aacad7ef83 [native] Include storageParameters in HiveConnectorSplit (Zac Wen)
- 8930308fe7a6d0fd097fa68a77bf9b579c35aa98 [native] Add queuedTimeInNanos in task stats (Ke)
- f7103fe0c052460c38328f0708a1127aeccbf0c3 [native] Fix presto_cpp includes (#24625) (Joe Giardino)
- 40fe92e51c1b56b35e8b9bdc18df4f4dcc06e029 [native] Add LinuxMemoryChecker check/warning to ensure system-mem-limit-gb is reasonably set (Minhan Cao)
- bd29a3876d129ed16d7096da7f51643425582f5b [native] Advance Velox (aditi-pandit)
- 2a99af43e046af807666f56a2e99b3b05dc90637 Add tracking of analysis time (Anant Aneja)
- 2a0999a107251adeed9937bf02ad5e01ab6e246c Move file-based metastore doc to installation/deployment.rst (Steve Burnett)
- 321a196c1f152bcaef8baa801ef4914661c599ae Add native prefix to hive session property (Ke)
- 75dce5110fbc63e5167c9db89a1d64cf15556a55 [Iceberg]Support setting warehouse data directory for Hadoop catalog (wangd)
- fe9729787347d6e1e37c5e4dea47754ffde06364 [Iceberg]Enable setting separate data write location on table creation (wangd)
- 56bf5e6c5bfbaac5df4cc09f2c99deb7750bf9fd Add hive session property to disable stats based filter reordering (Ke)
- 0927c8ff3bacc5132835b875b4c14d56e0759828 [Iceberg] Enable affinity scheduling on file sections (Zac Blanco)
- f9caa398858dd5a4b647fc68024ccd74ed3f6a91 Move Tableau page to Clients menu (dnskr)
- c14f8b44bb81c9e268ede1a6383d381cd4c3103d fix(iceberg): Date partition value parse issue (Mahadevuni Naveen Kumar)
- 84858392d8378408088552929d53514a1ec9c586 [native] Fix custom type headers in unit tests (Kevin Wilfong)
- 841932cc1b6fd48a7db8593decac40eee8a80b48 Correct catalog name for iceberg tests (Reetika Agrawal)
- 77d55e92e9651f977c3b9bed014b62019198b279 Add troubleshooting topic to documentation (Steve Burnett)
- 7088216c1f58c3e1389032c167fefe4b08c3f23d [codemod] Deshim //folly/experimental:threaded_repeating_function_runner in fbcode (Nicholas Ormrod)
- e5a1d91f972b5a3771de22ee324f1a6b2559d018 Move Java page to Clients menu and fix references (dnskr)
- bd095dc8258b03ab94b7aa7e49fe50a3bed2d298 Consolidate Presto CLI documentation on clients/presto-cli.rst page (dnskr)
- abb339972857c36f772cbac299b1ecff1f4144c5 [native] Advance velox. (Amit Dutta)
- e57c252d6b886003e2af09a8326c8ae60bf8b313 Add ConnectorDeleteTableHandle to support DELETEs (Shelton Cai)
- 4b8271c1d19f04a6af3f5975a705f1379a2415e2 [native] Support specification of node pool type in announcer (jay.narale)
- b12e90d6db6b94f985bea2697ab5610cdaefaa29 Upgrade org.apache.ratis dependency to address CVE-2020-15250 (Sumi Mathew)
- d6bc3e2d964522cae69c87cd46f7e572f8e914e6 [native] Advance Velox (Kevin Wilfong)
- 95dc1555499e0a33fefb64808a0bb6754998d974 Add documentation to note "-gb" Prestissimo Configs are using GiB units and not gB units (Minhan Cao)
- 0041846b8f50a4407f41e003496769cd50debc01 Fix approx_percentile to have constant pct for input rows (#24600) (Yuanda (Yenda) Li)
- e2ee434321cdf93301e63f09a7a862863dca6a1f Add checkQueryIntegrity to DispatchManager and Add schema/catalog to AccessControlContext (Kevin Tang)
- 15afc5c847f21253db0d8d1a6fd44abd4c831ed9 Use builder pattern for IcebergQueryRunner (Zac Blanco)
- a766a3a1ecd5fa45426977bc05e707da5d1c138c Revert "Assign event loop to tasks and run methods from a task in the same event loop" (Shang Ma)
- d6ce44031fbc903944c96bd7bc0be1e1634d946b Revert "Use a safe eventLoop wrapper to avoid thread shutdown and fail the task correctly" (Shang Ma)
- 84efc9094fcb4c6607cc4ee3ccda8e882ea2098d Add config property 'tpcds.use-varchar-type' (Pratik Joseph Dabre)
- 0c546f7236380381bdefdefcbe0f61a0fd166427 [native] Advance Velox (aditi-pandit)
- ea7dfa86e5e6e0c9b209d82fcaea4f1ef1a6c43a Update error code for checkElementNotNull used in array comparison operators (#24570) (XiaoDu)
- d6c5af64c85ef9766022a71631a86e1b2d029f3f Upgrade libthrift to 0.14.1 due CVE-2020-13949 (Denodo Research Labs)
- 4a0bbc9bbb22362a5c60ccf22b50c3a69058fd58 Subclass `FileHiveMetastore` for Iceberg connector (wangd)
- d7c09304a8d5131cd1204c66f11473379bc59def Improve boostrap log to expose the wrong classLoader (#24533) (Eric Liu)
- db0fe87053dfb68ee13f6e2fe7b5229cde2d94eb Add bootstrap icon to the vendor folder (Yihong Wang)
- 9c4b6838a6edd2a5b5daa8759bff0a4c4e0a5700 Fix dropdown style and diagram text alignment (unidevel)
- c1ec5a75c85e56ab65aebe049e022661713b46a3 [Iceberg] Session property for target split size (Zac Blanco)
- 8accda9714471c15bdc0c8abafcb9e0a4ba9c176 [native] Add support for ORC reader and add orc native tests (wypb)
- 7bdad6d3032d5d930e73f24bc91deb2dcf08425d Pass ConnectorSession to PlanChecker.validate (Rebecca Schlussel)
- 4435387a67c000f456f6cd756dd22b682ca1ea29 Add forConnectorId method to ConnectorSession (Rebecca Schlussel)
- d6b494a8a0254edd8abcf34e8a3bef80b0118976 Fix failing variadic functions when sidecar is enabled (Pratik Joseph Dabre)
- 2ec76133aef912bf5ce07f2d68cca61a4c70eada fixed view uuid type parsing (ajay-kharat)
- 704bcc92e1f605f63e93a361f0e7619a0deceef4 Fix formatting in properties.rst and base-arrow-flight.rst (Steve Burnett)
- 700fdc798abf484cff9ac2eca31791c58924834b [native] Advance velox. (Amit Dutta)
- db92976f0e438ee2b95872425d8a7b268a967187 [Iceberg]Support renaming table on hive file catalog (wangd)
- 652026bf439ca15733a5e2ca7098a5e09be79c4c add mysql compatible function bit_length (shenh062326)
- 03b8cd9e9c670fbcb48b9903e1c2a0236e66b4d4 Make event loop thread number configurable (Shang Ma)
- 6f16d8c4436759f4d95109ef6d6613f2878e0c1c Update presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifierConfig.java (Sergey Pershin)
- 88ee973b3ffa679fdc96f8491eba4c38fa2b910a Add 'use-test-checksum-in-determinism-analyzer' config property to Verifier. (Sergey Pershin)
- 6f09c5703159f1e0e897f50d8ccb87731c4220b4 Add support to disable task update size tracking (Nikhil Collooru)
- b190fe8d42eeb7023d540aaf390f4e15fe2e5818 Remove synchronization for updateFinalTaskInfo() (Nikhil Collooru)
- 99ea15b7d528b08f49ee559b4c29a518bb3daa3d Add `Join PrestoDB on Slack` link on doc pages (Yihong Wang)
- 089fcf8eafa19d3c999d29a5667fc48ed138f0bb Fix GH Actions for doc-only PR (Yihong Wang)
- d08c27ec6d034d5748ad5cd00709ff9459ef83b4 Fix duplicate TABLE_TYPE listing for view from system.jdbc.tables (Reetika Agrawal)
- ddb5baea38fcc786ecad36c73941a38066315b4b Fix enhanced_scheduling_property name (jaystarshot)
- c85d3d3fa1995a966466b077ed9eb497d4f45d93 Upgrade log4j-core and log4j-api dependencies (Dilli-Babu-Godari)
- 7d69b0a4fc71a31d8075d598fbf42cda60e93bfb [native] Advance velox. (Amit Dutta)
- 1f6195770a92c3509abaf9c59c6facc6357dbeb6 Record http client transaction create delay time (Ke)
- 1c43927b4746760cbd6cd188ddd1e4d409e539cf Package all resources into query_view_spa.html (#24486) (Li Zhou)
- 0370282411863b0388d83dbc2fe309d9d1377487 Arrow Flight module - do not bind class to itself (#24540) (Elbin Pallimalil)
- 18cef11d0f69d6ac7ed985ebb8297f200423eba7 Add documentation for file-based metastore (Steve Burnett)
- b8354095ae35f46a0f7e6f5fc2399d544d5ba24d Upgrade bootstrap and jquery for single page app (Yihong Wang)
- e2571abd38e96d3577ddfcd023f46d1eb7ee73fb Update presto console docs (Shahad)
- 2d830a3db1f8d9f2fb7967c07d1badd4fa7b7db5 add signature index and event type for type safety (Shahad)
- 37a1f58726126f0c188cae780dcbe6b3e1f1039e fix(dependencies): switch from dagre-d3 to dagre-d3-es (Shahad)
- 77b64b0e91efeb3b7479190a5ef87d62429eb203 Added data sanitization to queryId and nodeId, along with encodeURIComponent to queryId & nodeId. (Shahad)
- bc90e9393b518e7a11a9deb65a9d5b1ad22e65fd Check if event ID exists before processing and prevent child events (Shahad)
- 0c3cdd4cd319a64b19f19ad5160982be4090ad19 Update stage navigation to match selected plan event (Shahad)
- ecc8faaddee70d1ec65a3fc1e4afc0c0351055a5 Fix issue with Node details not showing on Stage page (Shahad)
- 859ed5010cbf4e8564d4cf34b29d17010e1efcaf Fixes: security issues for webapp jquery and bootstrap (Shahad)
- 2c5f9291eaa8c2f2d86193153334d755cf21d504 Fix compilation failure after merging AddExchangeBeforeGroupId (Zac Blanco)
- e84e4d21c8a1429095a180f5152de0b988b998d2 Add Exchange before GroupId to improve Partial Aggregation (Anant Aneja)
- 828e81f030f12e9ba2993f15817a72e3a890aeae Add Lateral join support in sql/select.rst (Steve Burnett)
- 099bd42eba287b1ea25bf55404c7a18882e0f6d5 [native] Derive TableScan stream type as FIXED (Andrii Rosa)
- 924d30995e7ed7152b9d9097c56552e8f86e38a9 Make ArrowFlightConfig verifyServer true by default (Bryan Cutler)
- 1a0c89129e8a1d315cc55cd79d27eaca8b6ea91c Adjust testing Arrow connector name to arrow-flight (Bryan Cutler)
- 3b5a705dabe67dd5b126356fbc50a99dcba00af3 Use setup-java@v4 parameter for CI dep caching (Zac Blanco)
- 504184ac45c88829230973b7231168faf4bd8245 Upgrade to actions/setup-java@v4 (Zac Blanco)
- 11adb6e0148aed913ab5c66f3fa34d56fdc8b50e [iceberg] Reformat incorrectly formatted files (Zac Blanco)
- 28efed392af21805fd0f16d2a4c1602b340cc571 [native] Advance velox. (Amit Dutta)
- a0f2ccb9f510d3a73cab3da132af6c479a945d79 re-add deleted subtraction test (librian415)
- d4417e41028eb39977d5b1c663eb454b0adeb5c0 remove leftover (librian415)
- ff20e13f637ebe36dace2f84dddfbcf801b17f39 lint (librian415)
- 9bf42cb00f8d919eb578ac246d3d54e8c342cea0 [Presto-Main] Add long overflow checks for IntervalDayTime (librian415)
- 7882d8308a31f3af270996ee767127f424ae1ed8 Add @czentgr as module committer for CI (#24519) (Timothy Meehan)
- 2005b0b6e49f49cb6a85e24faef4f7eecd3503ea Add support for UPDATE in iceberg (Zac Blanco)
- 4e3cf23c706d67e0ad811ac2096520407a0c1f5f Prevent exception when no input for update (Zac Blanco)
- 0299a29998d9bba15bc9ed58e6ecdbe82ec99b6e [native] Allow options for wget and tar commands during setup (Shakyan Kushwaha)
- f02046f22ae01af401ece030f28329cac78524e3 Avoid creating expensive Path objects in split creation code (Nikhil Collooru)
- 003d86a284a20bcf7749987237c790c1d3476361 Add Support for Iceberg table sort orders (Nidhin Varghese)
- 069a16f428c9288caca994077710edd7eeec6bbb Remove duplicate mapping from iceberg docs (auden-woolfson)
- 8789cd97fd6149cae96de952ad5fb5690425d5f3 Upgrade commons-text dependency to address CVE-2024-47554 (#24467) (sumi-mathew)
- 4615d4314634609dcf15cb9d5f729009602dbdac [native] Advance velox. (Amit Dutta)
- 16b447b374001af915da54339311dc0442a9934f [iceberg] Fix StatisticsFileCache JMX bean (Zac Blanco)
- 53da02f87838da40f0dbee04bbb1c30f07ce9f82 [iceberg] Fix bug on StatisticsFileCache miss (Zac Blanco)
- 744f1bb977c8cc4531dc9645a645191c139797b6 [native] Trigger presto-native-sidecar-plugin test workflow when changes occur (Pratik Joseph Dabre)
- a6d82fe0a5adc650458da9e18c119b2b55fb8ee8 [native] Add clang installation to dependency image and update image (Christian Zentgraf)
- 673c80f5a847d4abf6d25105af0cd05c009cf57f [native] Detect companion functions from velox function metadata (Pramod Satya)
- 391541a831bdcd0b65d3ebb361b8324019977f0b Add operator override for xxhash64, combine_hash internal functions (#24503) (Pradeep Vaka)
- f6ffef09e7118714e2841c67461834e53a81f631 Upgrade airbase and presto-maven-plugin (#24357) (Zac Blanco)
- 7119aa22d651c91e7059588d3b57d2d08e555dbd Update security protocol to TLS (Shahim Sharafudeen)
- 903520ce3f01b3d92eb1a6e4d5cbdd47035f7409 Upgrade cache Github action to v4 (Pramod Satya)
- 02f8f9f8c89f8f36a16c0cdb95aac43132174a33 [native] Add a config property for excluding invalid worker session properties (Pratik Joseph Dabre)
- be5fe8c26625b8be1ee4d4de6cb5ac5cb742d1f8 [native] Update include for ConfigTest.cpp (Amit Dutta)
- 1b51466641d82817e80fb63ed15a09e9e8388964 Update Presto version in example command (Steve Burnett)
- 6438c4a429a3939969f9552b3b94dc5c41c4d063 [native] Advance velox and fix unit tests. (Amit Dutta)
- 81e31fea896b8f3dbb5d35cbae9ae956fa357ec8 Fix typo in clients/go.rst and js.rst (Steve Burnett)
- a0c9b23719bd6f05cc7ecd49b7ade61b7807279b Update pull_request_template.md to remove PR link examples (Steve Burnett)
- a7f6cfe716f9a5c3ee5b5f481905ee737a881480 Add JavaScript client to documentation (Steve Burnett)
- 1176ffd2a8ba8c73d7bf5944b7707840db37d43a Fix getting views for Hive metastore (Sayari Mukherjee)
- 928fdb314d7b570604aeba72dbc906a64b446cc8 [native] Switch to use Clang for the Linux debug build in the CI (Christian Zentgraf)
- a8a6ffdf2c4a8b389fe80fb4726d6628520dda9e Fix build failure on JDK 11 (Zac Blanco)
- dbc1c15ab5c7aa27c21056a31d1b454901f079a8 Add new error code for queries killed due to too many tasks on cluster (Patrick Sullivan)
- a7a7f803e373716836e8a7ad3becd65fa1017016 Expose getting base directory (Yuanda (Yenda) Li)
- d4c632aa1dffa89b59af5459d7bd7cd097a3c161 [native] Advance velox. (Amit Dutta)
- e4be8761f816112c1eb992a04bc579485f2d5b1d Add OpenAPI documentation for /v1/functions (Pratik Joseph Dabre)
- 552cd86bf25613c1bd535271175ec414fed73fa4 [native] Integrate SPI with sidecar and add e2e native function validation tests (Pratik Joseph Dabre)
- f54c4987c0d558cd97067c9b44b24ecd6b4a76e0 [native] Introduce native function namespace SPI (Pratik Joseph Dabre)
- 092dd365b3d76ad8eff9ab15412b7eac12e00305 Change built-in namespace to JAVA_BUILTIN_NAMESPACE (Pratik Joseph Dabre)
- c34b63a5368cbc36cc5b02451464664794449494 Add a new module presto-function-namespace-managers-common (Pratik Joseph Dabre)
- 55060ed9666a17794242ee702a26768493e85f60 [native] Add additional function metadata to function signatures endpoint (Pratik Joseph Dabre)
- 54de1aa13f5d84a6ec04b7cdfd002c3f04d4bd75 Add utility functions to resolve intermediate type in generic aggregate functions (Pratik Joseph Dabre)
- 543b48eedaafb1977af5e712036480551c22313c [native] Add presto.default-namespace Prestissimo config property (Pratik Joseph Dabre)
- 719bfe2a4d35703e04b3127f6db9d37b94e8dc8c [native] Fix varchar cast for json (#24396) (Natasha Sehgal)
- 14063ed40a7f107cbd597edc398ce2d5f04d9471 Add support for loading plugins in the function server (Abe Varghese)
- 892ad684d9c1dfc575f039c17e818534e0df78cc Upgrade accumulo to 1.10.1 to fix CVE-2020-17533 (namya28)
- ec9e9046af36279ee2f6fda215dba34f4ca7ab81 Add support for timestamps with timezone in iceberg type converter (auden-woolfson)
- dd1893ccf11270a106b982e29ba6227f9c336f50 Add reference REST function server (Abe Varghese)
- 8041eb5e3ae0dc6e6a656d3e68d90ed8e1fda099 Add REST based Function Namespace Manager (Abe Varghese)
- 6aca572a49c54b86a244846293935424a1a15f15 upgrading hive-dwrf version to 0.8.7 (namya28)
- 08fe81c2aa3397cb0fab4ece469ebcc9cd0ac8a9 Revert " Upgrade Okie to version 3.6.0 and OkHttp to version 4.12.0" (Andrii Rosa)
- 44641296d4108c2c17f619c2e98b512148fccfe7 Adding Arrow Flight connector template (#24427) (Bryan Cutler)
- c229714f890b9e8159bcf91f112980f83cea2c00 Use ExpressionOptimizerProvider (Tim Meehan)
- 51ae5a549961490ecf6bf5c6e3b0d966f974bb54 Add ExpressionOptimizerManager (Tim Meehan)
- d477ea121def1cdf9175b20abec15f0c16f7abe4 Add SPI to customize expression optimization (Tim Meehan)
- fd1012900c9a683419c44b46103266d1a5bca07d [native] Suppress connector values from being logged (Christian Zentgraf)
- 0d8548313fb8ed197d11a4e9ac1257f177364189 [native] Add missing catalog configurations to docker image (Christian Zentgraf)
- 373a1d7a5c7414ca5588b491327987a313ee9ac3 Record CPU time on various planning stages (Andrii Rosa)
- af6399ab923ab74c0002aadb37d4e2c8de13af65 Avoid batch reading of nested decimals as this reader is not implemented (#24440) (Denodo Research Labs)
- e223cc163bdb78cbfffaca2221e4ed05e98457e1 [native]Switch to use subfiled filters in dwio common (Xiaoxuan Meng)
- 510024dcbcb0d36785cf2f4fc3f80488d4b6730d Improve the merging of operator stats (Shang Ma)
- 3f4e4c3555cff1f7ce6c08d9edb219a4638a8ff9 Update git config and environment in the presto stable release pipeline (#24441) (unidevel)
- 01bdab4244f3a1516faf4d24940dc12595927b3c Upgrade Okie to version 3.6.0 and OkHttp to version 4.12.0 (Mariam AlMesfer)
- 3da462fab9faf47283e71b9df8a12199cb76f579 [native]Reference hive connector util for subfield filter (Xiaoxuan Meng)
- 55fe7975f8a6eca3f79f382f9d2f58a0a0a2f4cb [Iceberg]Fix jmx metrics overwrite each other between nodes in query runner (wangd)
- bbf20b5fe6cba8492919893217e574b29c93f622 Add python and go to /clients (#24425) (Steve Burnett)