### PR TITLE
Add release notes for 0.293

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    Release-0.293 [2025-05-30] <release/release-0.293>
     Release-0.292 [2025-03-28] <release/release-0.292>
     Release-0.291 [2025-01-27] <release/release-0.291>
     Release-0.290 [2024-11-01] <release/release-0.290>

--- a/presto-docs/src/main/sphinx/release/release-0.293.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.293.rst
@@ -1,0 +1,113 @@
+=============
+Release 0.293
+=============
+
+**Highlights**
+==============
+
+**Details**
+===========
+
+General Changes
+_______________
+* Fix ROLLBACK statement to ensure it successfully abort non-auto commit transactions corrupted by failed statements. `#23247 <https://github.com/prestodb/presto/pull/23247>`_
+* Fix Router Round robin scheduler candidate cluster index, by adding group specific index. `#24580 <https://github.com/prestodb/presto/pull/24580>`_
+* Fix a bug in left join to semi join optimizer which leads to filter source variable not found error. `#25111 <https://github.com/prestodb/presto/pull/25111>`_
+* Fix a bug where a mirrored :func:`arrays_overlap(x, y) -> boolean` function does not return the correct value. `#23845 <https://github.com/prestodb/presto/pull/23845>`_
+* Fix returning incorrect results from the "second" UDF when a timestamp is in a time zone with an offset that is at the granularity of seconds. `#25090 <https://github.com/prestodb/presto/pull/25090>`_
+* Fix the issue of sensitive data such as passwords and access keys being exposed in logs by redacting sensitive field values. `#24886 <https://github.com/prestodb/presto/pull/24886>`_
+* Improve ACL check by moving checkQueryIntegrity from Dispatch phase to Analyzer phase. `#24927 <https://github.com/prestodb/presto/pull/24927>`_
+* Improve communication between coordinator and worker with thrift serde. `#25079 <https://github.com/prestodb/presto/pull/25079>`_
+* Improve communication between coordinator and worker with thrift serde. `#25020 <https://github.com/prestodb/presto/pull/25020>`_
+* Improve how we merge multiple operator stats together. `#24921 <https://github.com/prestodb/presto/pull/24921>`_
+* Improve metrics creation by refactoring local variables to a dedicated class. `#24921 <https://github.com/prestodb/presto/pull/24921>`_
+* Improve performance of ORDER BY queries on single node execution :pr:`25022`. `#25022 <https://github.com/prestodb/presto/pull/25022>`_
+* Improve query plans using the ``SimplifyPlanWithEmptyInput`` optimizer to convert a table scan which returns no data to an empty values node. `#25155 <https://github.com/prestodb/presto/pull/25155>`_
+* Add DDL SQL support for ``SHOW CREATE SCHEMA``. `#24356 <https://github.com/prestodb/presto/pull/24356>`_
+* Add authentication capabilities to Presto router. `#24407 <https://github.com/prestodb/presto/pull/24407>`_
+* Add configuration property ``hive.metastore.catalog.name`` to pass catalog names to the metastore, enabling catalog-based schema management and filtering. `#24235 <https://github.com/prestodb/presto/pull/24235>`_
+* Add coordinator health checks to Presto router. `#24449 <https://github.com/prestodb/presto/pull/24449>`_
+* Add counter JMX metrics to Presto router. `#24449 <https://github.com/prestodb/presto/pull/24449>`_
+* Add example custom scheduler plugin - Metrics based custom scheduler plugin. `#24439 <https://github.com/prestodb/presto/pull/24439>`_
+* Add support for custom scheduler plugin. `#24439 <https://github.com/prestodb/presto/pull/24439>`_
+* Add type rewrite support for native execution. This feature can be enabled by ``native-execution-type-rewrite-enabled`` configuration property and ``native_execution_type_rewrite_enabled`` session property. :pr:`24916`. `#24916 <https://github.com/prestodb/presto/pull/24916>`_
+* Add view definitions from Analyzer phase to perform full integrity check on query credentials. `#24955 <https://github.com/prestodb/presto/pull/24955>`_
+* Replace `exchange.compression-enabled`,  `fragment-result-cache.block-encoding-compression-enabled`, `experimental.spill-compression-enabled` with `exchange.compression-codec`, `fragment-result-cache.block-encoding-compression-codec` to enable compression codec configurations. Supported codecs include GZIP, LZ4, LZO, SNAPPY, ZLIB and ZSTD. `#24670 <https://github.com/prestodb/presto/pull/24670>`_
+* Replace dependency from PostgreSQL to redshift-jdbc42 to address 'CVE-2024-1597 <https://github.com/advisories/GHSA-24rp-q3w6-vc56>', 'CVE-2022-31197 <https://github.com/advisories/GHSA-r38f-c4h4-hqq2>' and 'CVE-2020-13692 <https://github.com/advisories/GHSA-88cc-g835-76rp>'. `#25106 <https://github.com/prestodb/presto/pull/25106>`_
+* Remove unused line of code from router module. `#25150 <https://github.com/prestodb/presto/pull/25150>`_
+* Change checkQueryIntegrity function signature in AccessControl interface to pass in view definitions as params. `#24955 <https://github.com/prestodb/presto/pull/24955>`_
+* Upgrade commons-compress version to 1.26.2 across the codebase to address 'CVE-2021-35517 <https://github.com/advisories/GHSA-xqfj-vm6h-2x34>' , 'CVE-2021-35516<https://github.com/advisories/GHSA-crv7-7245-f45f>', 'CVE-2021-36090 <https://github.com/advisories/GHSA-mc84-pj99-q6hh>', 'CVE-2021-35515 <https://github.com/advisories/GHSA-7hfm-57qf-j43q>' and 'CVE-2024-25710 <https://github.com/advisories/GHSA-4g9r-vxhx-9pgx>'. `#25106 <https://github.com/prestodb/presto/pull/25106>`_
+* Upgrade kotlin-stdlib-jdk8 to 1.9.25. `#24971 <https://github.com/prestodb/presto/pull/24971>`_
+* Upgrade netty version to 4.1.119.Final. `#24971 <https://github.com/prestodb/presto/pull/24971>`_
+* Upgrade okio-jvm version to 3.9.1. `#24971 <https://github.com/prestodb/presto/pull/24971>`_
+* Upgrade slf4j version to 1.7.36. `#24971 <https://github.com/prestodb/presto/pull/24971>`_
+* Upgrade snappy-java version at 1.1.10.4 across the codebase to address 'CVE-2023-43642 <https://github.com/advisories/GHSA-55g7-9cwv-5qfv>'. `#25106 <https://github.com/prestodb/presto/pull/25106>`_
+
+General Change Changes
+______________________
+* Improve memory usage in reader with nested readers by resetting all nested readers. `#24912 <https://github.com/prestodb/presto/pull/24912>`_
+
+Prestissimo (Native Execution) Changes
+______________________________________
+* Fix REST API call ``v1/operator/task/getDetails?id=`` crash. `#24839 <https://github.com/prestodb/presto/pull/24839>`_
+* Replace using native functions with Java functions for creating failure functions when native execution is enabled. `#24792 <https://github.com/prestodb/presto/pull/24792>`_
+
+Prestissimo (native Execution) Changes
+______________________________________
+* Fix issue with PartitionAndSerialize re-using only keys from the first batch of data. `#25015 <https://github.com/prestodb/presto/pull/25015>`_
+* Add BinarySortableSerializer tests with VectorFuzzer. `#24954 <https://github.com/prestodb/presto/pull/24954>`_
+* Add runtime metrics collection for S3 Filesystem. `#24554 <https://github.com/prestodb/presto/pull/24554>`_
+* Add supported for sort in PartitionAndSerialize operator. `#24953 <https://github.com/prestodb/presto/pull/24953>`_
+* Removes worker config `register-test-functions`. `#24853 <https://github.com/prestodb/presto/pull/24853>`_
+
+Security Changes
+________________
+* Add security-related headers to the static resources served from the Presto Router UI, including: ``Content-Security-Policy``, ``X-Content-Type-Options``. See reference docs `Content-Security-Policy <https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP>`_ and  `X-Content-Type-Options <https://learn.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/compatibility/gg622941(v=vs.85)>`_. :pr:`24272`. `#25165 <https://github.com/prestodb/presto/pull/25165>`_
+* Add support for access control row filters and column masks on views. `#25052 <https://github.com/prestodb/presto/pull/25052>`_
+* Add support for row filtering and column masking in access control. `#24277 <https://github.com/prestodb/presto/pull/24277>`_
+* Upgrade commons-beanutils to version 1.9.4 in response to `CVE-2014-0114 <https://nvd.nist.gov/vuln/detail/CVE-2014-0114>`_. `#24665 <https://github.com/prestodb/presto/pull/24665>`_
+* Upgrade plexus-utils to version 3.6.0 in response to `CVE-2017-1000487 <https://nvd.nist.gov/vuln/detail/cve-2017-1000487>`_. `#24665 <https://github.com/prestodb/presto/pull/24665>`_
+* Upgrade zookeeper to 3.9.3 to fix security vulnerability in presto-accumulo, presto-delta,presto-hive,presto-kafka and presto-hudi  in response to `CVE-2023-44981 <https://nvd.nist.gov/vuln/detail/cve-2023-44981>`_. `#24403 <https://github.com/prestodb/presto/pull/24403>`_
+
+Delta Connector Changes
+_______________________
+* Fix a bug where after an incremental update with null values is made reads start timing out. `#24920 <https://github.com/prestodb/presto/pull/24920>`_
+
+Elasticsearch Connector Changes
+_______________________________
+* Upgrade elasticsearch to 7.17.27 in response to `CVE-2024-43709 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-43709>`_. `#23894 <https://github.com/prestodb/presto/pull/23894>`_
+
+Hive Connector Changes
+______________________
+* Add support for Web Identity authentication in S3 security mapping with the ``hive.s3.webidentity.enabled`` property. `#24645 <https://github.com/prestodb/presto/pull/24645>`_
+* Replace listObjects with listObjectsV2 in PrestoS3FileSystem listPrefix. `#24794 <https://github.com/prestodb/presto/pull/24794>`_
+
+Iceberg Connector Changes
+_________________________
+* Fix to pass full session to avoid ``Unknown connector`` errors using the Nessie catalog. `#24803 <https://github.com/prestodb/presto/pull/24803>`_
+* Add support for the procedure <catalog-name>.system.invalidate_manifest_file_cache() for ManifestFile cache invalidation in Iceberg. `#24831 <https://github.com/prestodb/presto/pull/24831>`_
+* Add support for the procedure <catalog-name>.system.invalidate_statistics_file_cache() for StatisticsFile cache invalidation in Iceberg. `#24831 <https://github.com/prestodb/presto/pull/24831>`_
+* Replace RowDelta with AppendFiles for insert-only statements such as INSERT and CTAS. `#24989 <https://github.com/prestodb/presto/pull/24989>`_
+* Support bucket transform for columns of type `TimeType` in Iceberg table. `#24829 <https://github.com/prestodb/presto/pull/24829>`_
+
+Kafka Connector Changes
+_______________________
+* Add support for optional Apache Kafka SASL. `#24798 <https://github.com/prestodb/presto/pull/24798>`_
+
+Mysql Connector Changes
+_______________________
+* Add support for GEOMETRY type in the MySQL connector. `#24996 <https://github.com/prestodb/presto/pull/24996>`_
+
+Sql Server Connector Changes
+____________________________
+* Note: Starting from this version, the driver sets the encrypt property to true by default. If you are connecting to a non-SSL SQL Server instance, you must explicitly set encrypt=false in your connection configuration to avoid connectivity issues. This is a breaking change for existing connections. `#24686 <https://github.com/prestodb/presto/pull/24686>`_
+* Upgraded SQL Server driver to version 12.8.1 to support NTLM authentication. See :ref:connector/sqlserver:authentication for more details. `#24686 <https://github.com/prestodb/presto/pull/24686>`_
+
+Documentation Changes
+_____________________
+* Document Presto C++ sidecar and native sidecar plugin. `#24883 <https://github.com/prestodb/presto/pull/24883>`_
+
+**Credits**
+===========
+
+Akinori Musha, Amit Dutta, Anant Aneja, Andrew Xie, Andrii Rosa, Anurag Dwivedi, Bryan Cutler, Chen Yang, Christian Zentgraf, Deepak Majeti, Deepak Mehra, Denodo Research Labs, Elbin Pallimalil, Emily (Xuetong) Sun, Ethan Zhang, Facebook Community Bot, Feilong Liu, Gary Helmling, Haritha Koloth, Hazmi, HeidiHan0000, Heng Xiao, Jacob Khaliqi, James Petty, Jay Narale, Jim Simon, Jimmy Lu, Joe Abraham, Ke Wang, Ke Wang, Kevin Tang, Kevin Wilfong, Krishna Pai, Li Zhou, Linsong Wang, Mariam Almesfer, Miguel Blanco Godón, Najib Adan, Natasha Sehgal, Nidhin Varghese, Nikhil Collooru, Nivin C S, Pradeep Vaka, Pramod Satya, Prashant Golash, Pratik Joseph Dabre, Rebecca Schlussel, Reetika Agrawal, Samuel Majoros, Sayari Mukherjee, Serge Druzkin, Sergey Pershin, Shahim Sharafudeen, Shang Ma, Shelton Cai, Shijin, Steve Burnett, Xiao Du, Xiaoxuan Meng, Xin Zhang, Yihong Wang, Ying, Yuanda (Yenda) Li, Zac Blanco, Zac Wen, aditi-pandit, auden-woolfson, ebonnal, jp-sivaprasad, lukmanulhakkeem, mecit-san, mohsaka, namya28, tanjialiang, vhsu14, wangd, wraymo


### PR DESCRIPTION
# Missing Release Notes
## Amit Dutta
- [ ] https://github.com/prestodb/presto/pull/25056 Add cosine_similarity function for two arrays (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/24823 [native] Advance velox. (Merged by: Amit Dutta)

## Emily (Xuetong) Sun
- [ ] https://github.com/prestodb/presto/pull/24739 Support sorted shuffle write in Sapphire-Velox stack (Merged by: Facebook Community Bot)

## Gary Helmling
- [ ] https://github.com/prestodb/presto/pull/24772 [native] Add DeleteNode translation to TableWriteNode in Velox query plan (Merged by: Gary Helmling)

## HeidiHan0000
- [ ] https://github.com/prestodb/presto/pull/24918 Add request-data-sizes-max-wait-sec to session properties (Merged by: HeidiHan0000)
- [ ] https://github.com/prestodb/presto/pull/24977 Add system configs to query configs mapping for requestDataSizesMaxWaitSec (Merged by: Ke)

## Heng Xiao
- [ ] https://github.com/prestodb/presto/pull/24835 Fix RedisProviderPlugin cannot be instantiated using reflection in Pl… (Merged by: Jay Narale)

## Jacob Khaliqi
- [ ] https://github.com/prestodb/presto/pull/24729 Change array_top_n to return null on bad n (Merged by: Aditi Pandit)

## Prashant Golash
- [ ] https://github.com/prestodb/presto/pull/24856 [presto] Add state filter to the queryState resource (Merged by: Rebecca Schlussel)
- [ ] https://github.com/prestodb/presto/pull/24830 [presto][ui] Display queued queries per subgroup RG (Merged by: Yihong Wang)

## Pratik Joseph Dabre
- [ ] https://github.com/prestodb/presto/pull/24759 [native] Add longVariableConstraints to function metadata (Merged by: Pratik Joseph Dabre)

## Samuel Majoros
- [ ] https://github.com/prestodb/presto/pull/24891 Add longest_common_prefix implementation, documentation and tests (Merged by: Steve Burnett)

## Shijin
- [ ] https://github.com/prestodb/presto/pull/24745 Changes to enable ssl/tls in hms (Merged by: Ying)

## Xiao Du
- [ ] https://github.com/prestodb/presto/pull/24864 revert json_extract to Produce Canonicalized Output (Merged by: XiaoDu)

## Yuanda (Yenda) Li
- [ ] https://github.com/prestodb/presto/pull/24941 [native] Save 1 memcpy in parsing message body (Merged by: Yuanda (Yenda) Li)

## aditi-pandit
- [ ] https://github.com/prestodb/presto/pull/24862 Add team-velox as code owners for presto-native-(sidecar-plugin|tests) modules (Merged by: Aditi Pandit)

## namya28
- [ ] https://github.com/prestodb/presto/pull/24754 Upgrading mysql jar in presto (Merged by: Reetika Agrawal)

## tanjialiang
- [ ] https://github.com/prestodb/presto/pull/24947 [native] Add session property for eager streaming aggregation flush (Merged by: tanjialiang)
- [ ] https://github.com/prestodb/presto/pull/24915 Add shared-arbitrator.memory-pool-abort-capacity-limit into property registry (Merged by: tanjialiang)
- [ ] https://github.com/prestodb/presto/pull/24884 Add distinct to the right side when LOJ + IS NULL is rewritten to Semijoin (Merged by: tanjialiang)
- [ ] https://github.com/prestodb/presto/pull/24833 Add memory pool debug regex (Merged by: tanjialiang)

# Extracted Release Notes
- #23247 (Author: wangd): Fix rollback after statement fail in non-autocommit transaction
  - Fix ROLLBACK statement to ensure it successfully abort non-auto commit transactions corrupted by failed statements.
- #23845 (Author: Hazmi): Fix ARRAYS_OVERLAP function bug
  - Fix a bug where a mirrored :func:`arrays_overlap(x, y) -> boolean` function does not return the correct value.
- #23894 (Author: Hazmi): Upgrade elasticsearch connector from 6 to 7
  - Upgrade elasticsearch to 7.17.27 in response to `CVE-2024-43709 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-43709>`_.
- #24235 (Author: Anurag Dwivedi): Add config to specify metastore catalog name
  - Add configuration property ``hive.metastore.catalog.name`` to pass catalog names to the metastore, enabling catalog-based schema management and filtering.
- #24277 (Author: Bryan Cutler): Add support for row filtering and column masking access control
  - Add support for row filtering and column masking in access control.
- #24356 (Author: Reetika Agrawal): Add support for SHOW CREATE SCHEMA
  - Add DDL SQL support for ``SHOW CREATE SCHEMA``.
- #24403 (Author: Shijin): Update zookeeper version to fix CVEs
  - Upgrade zookeeper to 3.9.3 to fix security vulnerability in presto-accumulo, presto-delta,presto-hive,presto-kafka and presto-hudi  in response to `CVE-2023-44981 <https://nvd.nist.gov/vuln/detail/cve-2023-44981>`_.
- #24407 (Author: auden-woolfson): Add authentication layer to presto router
  - Add authentication capabilities to Presto router.
- #24439 (Author: jp-sivaprasad): Custom scheduler plugin support
  - Add support for custom scheduler plugin.
  - Add example custom scheduler plugin - Metrics based custom scheduler plugin.
- #24449 (Author: auden-woolfson): Add health check to route queries to healthy cluster and router jmx counter updates
  - Add coordinator health checks to Presto router.
  - Add counter JMX metrics to Presto router.
- #24554 (Author: Xin Zhang): [native] Add S3 metrics reporting
  - Add runtime metrics collection for S3 Filesystem.
- #24580 (Author: jp-sivaprasad): Router scheduler fixes and unit test case enhancements
  - Fix Router Round robin scheduler candidate cluster index, by adding group specific index.
- #24645 (Author: Sayari Mukherjee): Enhance S3 Web Identity authentication & security mapping
  - Add support for Web Identity authentication in S3 security mapping with the ``hive.s3.webidentity.enabled`` property.
- #24665 (Author: Mariam Almesfer): Upgrade plexus-utils and commons-beanutils
  - Upgrade commons-beanutils to version 1.9.4 in response to `CVE-2014-0114 <https://nvd.nist.gov/vuln/detail/CVE-2014-0114>`_.
  - Upgrade plexus-utils to version 3.6.0 in response to `CVE-2017-1000487 <https://nvd.nist.gov/vuln/detail/cve-2017-1000487>`_.
- #24670 (Author: Xin Zhang): Add compression codec support for PageSerde
  - Replace `exchange.compression-enabled`,  `fragment-result-cache.block-encoding-compression-enabled`, `experimental.spill-compression-enabled` with `exchange.compression-codec`, `fragment-result-cache.block-encoding-compression-codec` to enable compression codec configurations. Supported codecs include GZIP, LZ4, LZO, SNAPPY, ZLIB and ZSTD.
- #24686 (Author: lukmanulhakkeem): Upgrade sqlserver driver to version 12.8.1
  - Upgraded SQL Server driver to version 12.8.1 to support NTLM authentication. See :ref:connector/sqlserver:authentication for more details.
  - Note: Starting from this version, the driver sets the encrypt property to true by default. If you are connecting to a non-SSL SQL Server instance, you must explicitly set encrypt=false in your connection configuration to avoid connectivity issues. This is a breaking change for existing connections.
- #24792 (Author: Pratik Joseph Dabre): Use Java built-in functions to create failure function
  - Replace using native functions with Java functions for creating failure functions when native execution is enabled.
- #24794 (Author: Deepak Mehra): [Hive] Use S3 listObjectsV2 in PrestoS3FileSystem listPrefix
  - Replace listObjects with listObjectsV2 in PrestoS3FileSystem listPrefix.
- #24798 (Author: Shahim Sharafudeen): Add support for optional kafka SASL
  - Add support for optional Apache Kafka SASL.
- #24803 (Author: Denodo Research Labs): Pass full session to avoid Unknown connector errors
  - Fix to pass full session to avoid ``Unknown connector`` errors using the Nessie catalog.
- #24829 (Author: wangd): [Iceberg]Support bucket transform for TimeType
  - Support bucket transform for columns of type `TimeType` in Iceberg table.
- #24831 (Author: Reetika Agrawal): [Iceberg] Cache invalidation procedure for Iceberg coordinator cache
  - Add support for the procedure <catalog-name>.system.invalidate_statistics_file_cache() for StatisticsFile cache invalidation in Iceberg.
  - Add support for the procedure <catalog-name>.system.invalidate_manifest_file_cache() for ManifestFile cache invalidation in Iceberg.
- #24839 (Author: Deepak Majeti): [native] Fix v1/operation/task/getDetail
  - Fix REST API call ``v1/operator/task/getDetails?id=`` crash.
- #24853 (Author: Pramod Satya): [native] Remove `register-test-functions` worker config
  - Removes worker config `register-test-functions`.
- #24883 (Author: Pramod Satya): Add sidecar and sidecar plugin documentation
  - Document Presto C++ sidecar and native sidecar plugin.
- #24886 (Author: Nivin C S): Fix sensitive data disclosure in logs
  - Fix the issue of sensitive data such as passwords and access keys being exposed in logs by redacting sensitive field values.
- #24912 (Author: Chen Yang): Reduce memory usage in reader by reset all underlying readers
  - Improve memory usage in reader with nested readers by resetting all nested readers.
- #24916 (Author: Zac Wen): Add NativeExecutionTypeRewrite
  - Add type rewrite support for native execution. This feature can be enabled by ``native-execution-type-rewrite-enabled`` configuration property and ``native_execution_type_rewrite_enabled`` session property. :pr:`24916`.
- #24920 (Author: Miguel Blanco Godón): Timeout reading delta tables after incremental updates with null values
  - Fix a bug where after an incremental update with null values is made reads start timing out.
- #24921 (Author: Shang Ma): Re-introduce improving the merging of operator stats
  - Improve how we merge multiple operator stats together.
  - Improve metrics creation by refactoring local variables to a dedicated class.
- #24927 (Author: Kevin Tang): Check Query integrity in Analyzer Util
  - Improve ACL check by moving checkQueryIntegrity from Dispatch phase to Analyzer phase.
- #24953 (Author: Emily (Xuetong) Sun): Support sorted shuffle write in Sapphire-Velox stack
  - Add supported for sort in PartitionAndSerialize operator.
- #24954 (Author: Emily (Xuetong) Sun): Use VectorFuzzer for BinarySortableSerializer test
  - Add BinarySortableSerializer tests with VectorFuzzer.
- #24955 (Author: Kevin Tang): Add view text hash info to accessControlReferences
  - Add view definitions from Analyzer phase to perform full integrity check on query credentials.
  - Change checkQueryIntegrity function signature in AccessControl interface to pass in view definitions as params.
- #24971 (Author: Hazmi): Upgrade several dependency versions
  - Upgrade slf4j version to 1.7.36.
  - Upgrade okio-jvm version to 3.9.1.
  - Upgrade kotlin-stdlib-jdk8 to 1.9.25.
  - Upgrade netty version to 4.1.119.Final.
- #24989 (Author: wangd): [Iceberg]Prefer `AppendFiles` over `RowDelta` in insert-only statement
  - Replace RowDelta with AppendFiles for insert-only statements such as INSERT and CTAS.
- #24996 (Author: Mariam Almesfer): Add support for geometry type in mysql connector
  - Add support for GEOMETRY type in the MySQL connector.
- #25015 (Author: Emily (Xuetong) Sun): Fix: Re-initialize sort key serializer for every new input added
  - Fix issue with PartitionAndSerialize re-using only keys from the first batch of data.
- #25020 (Author: Shang Ma): Make taskUpdateRequest and taskInfo classes Thrift ready with json fields
  - Improve communication between coordinator and worker with thrift serde.
- #25022 (Author: Andrii Rosa): Fix distributed sort parallelism for single node execution
  - Improve performance of ORDER BY queries on single node execution :pr:`25022`.
- #25052 (Author: Bryan Cutler): Enable access control row filters and masks for views
  - Add support for access control row filters and column masks on views.
- #25079 (Author: vhsu14): [native] Migrate TaskStatus, TaskUpdateRequest, TaskInfo to Thrift with JSON fields in CPP
  - Improve communication between coordinator and worker with thrift serde.
- #25090 (Author: Kevin Wilfong): Fix second UDF not respecting sub-minute time zone offsets
  - Fix returning incorrect results from the "second" UDF when a timestamp is in a time zone with an offset that is at the granularity of seconds.
- #25106 (Author: Shahim Sharafudeen): Fix vulnerability issues on presto-redshift, commons-compress and snappy-java
  - Upgrade commons-compress version to 1.26.2 across the codebase to address 'CVE-2021-35517 <https://github.com/advisories/GHSA-xqfj-vm6h-2x34>' , 'CVE-2021-35516<https://github.com/advisories/GHSA-crv7-7245-f45f>', 'CVE-2021-36090 <https://github.com/advisories/GHSA-mc84-pj99-q6hh>', 'CVE-2021-35515 <https://github.com/advisories/GHSA-7hfm-57qf-j43q>' and 'CVE-2024-25710 <https://github.com/advisories/GHSA-4g9r-vxhx-9pgx>'.
  - Replace dependency from PostgreSQL to redshift-jdbc42 to address 'CVE-2024-1597 <https://github.com/advisories/GHSA-24rp-q3w6-vc56>', 'CVE-2022-31197 <https://github.com/advisories/GHSA-r38f-c4h4-hqq2>' and 'CVE-2020-13692 <https://github.com/advisories/GHSA-88cc-g835-76rp>'.
  - Upgrade snappy-java version at 1.1.10.4 across the codebase to address 'CVE-2023-43642 <https://github.com/advisories/GHSA-55g7-9cwv-5qfv>'.
- #25111 (Author: Feilong Liu): Fix filter source variable not found bug in left join to semi join optimizer
  - Fix a bug in left join to semi join optimizer which leads to filter source variable not found error.
- #25150 (Author: auden-woolfson): Remove duplicate binding in router module
  - Remove unused line of code from router module.
- #25155 (Author: Feilong Liu): Run empty values node simplify optimizer after connector optimizer
  - Improve query plans using the ``SimplifyPlanWithEmptyInput`` optimizer to convert a table scan which returns no data to an empty values node.
- #25165 (Author: jp-sivaprasad): Presto router - Add security related headers for static resources served from Presto Router UI
  - Add security-related headers to the static resources served from the Presto Router UI, including: ``Content-Security-Policy``, ``X-Content-Type-Options``. See reference docs `Content-Security-Policy <https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP>`_ and  `X-Content-Type-Options <https://learn.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/compatibility/gg622941(v=vs.85)>`_. :pr:`24272`.

# All Commits
- 5bbdf93ce8b5b9c745a824141d35666233144384 [native] Remove unused includes. (Amit Dutta)
- 57a85ce3d903ce5190f30c523def48fe3804eab8 [native] Advance velox. (Amit Dutta)
- c21e043181395710bacfdcdcf60d45921af3b598 [native] Advance Velox (aditi-pandit)
- cd4321f61a0bad02d77042aaf7db29bac181d857 Fix formatting in sql/show-create-schema.rst (Steve Burnett)
- bb7766523b4b136c0bb9ef55f7a3ec0463ffa969 fix a build issue in presto-docs (wraymo)
- 6d896c73563ade079ef006500540a10338d20406 [native] Use release dependency image (Deepak Majeti)
- b11f358df710e05d78a913f01ce2a12dd9f4e591 Update plugin to generate idl thrift file automatically (#25164) (Shang Ma)
- c1395eeb6a0ddd6c1660a5a22ab79431790ac336 Fix flaky test: TestOutputColumnTypes.testOutputColumnsForInsertAsSelect (Nidhin Varghese)
- fcc4735b1b0c65e81cbd55cfddcee4a51d5ea74a Run empty values node simplify optimizer after connector optimizer (Feilong Liu)
- 484b00e0a0d031eef4b9e1b9ad51618495746494 Fix formatting in /functions/ (Steve Burnett)
- 274e05a437eb8724fdbffdccec5893511da15adb Add support for geometry type in mysql connector (Mariam Almesfer)
- f9c336df3498b8d88d0cced9b12750bee9038dc7 [Iceberg]Explicitly close the transactions opened manually in tests (wangd)
- b566980241fe4ef65f0f3db3e0c00148033136ef Add support for SHOW CREATE SCHEMA (Reetika Agrawal)
- 675e65e5f6cef5fa2dd4cd0f286c72f0ced8ca8e Use Java built-in functions to create failure function (Pratik Joseph Dabre)
- 76344abe1004ffc00056ba902ff22dbf70a8cc00 Add Request Header Fields Too Large to /troubleshoot/ (Steve Burnett)
- 61f03871f59dfff90bf67fd3083ebd32cd52e947 [native] Advance Velox and Dependency Versions (Christian Zentgraf)
- c152806e57dffbb4384bc1ee3c118acceff8f878 Add timeouts to presto-router TestHealthChecks (Zac Blanco)
- db01390a2d188217e46e0c62a033239aaa47844d Fix ClusterManager failing to poll (Zac Blanco)
- 6f094ae46fa9a85830bcc2f42d0e8b041ead6f1b Add presto-testng-services to presto-router (Zac Blanco)
- 14da967b56de29edeca67ac2226c4a92160c1ea5 Presto router - Add security related headers for static resources for UI (jp-sivaprasad)
- 3ebef98743d42cfdda3035933ea082357252bae5 Upgrade node to 22.15.1 (Andrew Xie)
- 0979ea72a35195680fc7b90f3322da977ea96628 Release action fixes and improvements (#24957) (Li Zhou)
- 9ee9d6562621150eebe8a18fe9b6e9be8de16060 [sidecar] Fix ANALYZE queries on varchar columns when sidecar is enabled (Pratik Joseph Dabre)
- 4766404e26d3a7cd43a9ccfd5b2fca190e9468dc Add http-server.max-request-header-size to properties.rst (Steve Burnett)
- 8286ffa9f56e6c3a2dbe0f8949fa19529e277f13 [native] Add optional Task queuing framework. (Sergey Pershin)
- f419d2fd2e058db854aebe498d4ae6c25dc7d4c6 Remove duplicate binding in router module (auden-woolfson)
- 8afbe05533dd1064c98a6fcc531ed5d64115bdf0 Add per-query-retry-limit to properties.rst (Steve Burnett)
- 867bf03123010ca1ce6a03723f5b33a96f87b0b3 Fix second UDF not respecting sub-minute time zone offsets (Kevin Wilfong)
- 60941a7c7a5c38fd18b3937376a129ecdcd04783 Fix vulnerability issues in postgresql, commons-compress and snappy-java (Shahim Sharafudeen)
- 5b4b71cab95503f69200fa63ffb865bb73f396df [native] Migrate TaskStatus, TaskUpdateRequest, TaskInfo to Thrift with JSON fields in CPP (#25079) (vhsu14)
- 9f77bed270474fb4f870344735d4624dffd65d4a Make taskUpdateRequest and taskInfo classes Thrift ready with json fields (#25020) (Shang Ma)
- 1fc56874282a85914a28bbb88638dcc9c9bb4e7b [native] Fix build order issues with presto_server (Christian Zentgraf)
- 58df37d6df18a927cd01b8fb6964e7d336434529 Add index join related nodes to plan matcher (Zac Wen)
- d6a136cc6b77a384576112c62869f7ad8eb44e5e [sidecar] Fix failing lambda test case in TestNativeSidecarPlugin (Pratik Joseph Dabre)
- be655be2ba24db416d7265dd9299963b4422494e presto router - custom scheduler plugin (jp-sivaprasad)
- 65b832b5cc86af6285c5b6c15acb36055ca379eb Add Test for QualifiedObjectName Regression in 0.292 (Jim Simon)
- 3da0e14058470c483fd88720f25ca4defb089ed7 Fix the partial aggregation pushdown for system table for native execution (Ke Wang)
- edfebc20e86827dac8bcfaaf6d542d197e37ff7e Fix filter source variable not found bug in left join to semi join optimizer (Feilong Liu)
- 8dd2b4c68ccc3259c28fda9284956489ff8675ac [native] Add Builder classes for custom PlanNodes (Kevin Wilfong)
- 3145f652783b0ebd295230897b4ae8c1a2734713 [sidecar] Fix array_sort lambda function failure when sidecar is enabled and add e2e lambda function tests (Pratik Joseph Dabre)
- 52fae2556597aee9684fa5fa99e868b641ed7f41 Revert "Change array_top_n to return null on bad n" (Aditi Pandit)
- 65becb03764711c6243c4a0febaf60cbc6bf43af Apply filters and masks for view object (Bryan Cutler)
- 51272bf7fcb0886a475e7e7e103fb945fe6970e4 Apply filters and masks for tables referenced by views (Bryan Cutler)
- 91c2c54f035e578b7c2be3bab218d7211a75f4c1 Change array_top_n to return null on bad n (Jacob Khaliqi)
- dda99ba09bfb14e16db200e0afe312e13c413b8b Add docs for router authentication (auden-woolfson)
- 9c704187e385c6548ffef1be86cd374e364bfb3a Add authentication layer to presto router (auden-woolfson)
- 065910a597ad0eaaf3bee9382058e71c16a755c1 Refactor PluginManager(s) to use PluginManagerUtil (auden-woolfson)
- b5a1eb78d9338b0d59e88a51bf1639ad12b64160 Fix redshift documentation (Reetika Agrawal)
- 09175f3244f038dd725eb2c4ff2c31cbe76063a5 Fix protocol generation to properly remove license (Bryan Cutler)
- 941ffb20d6a0a807d61103a1594fd8806d843abf Add request-data-sizes-max-wait-sec to session properties (#24918) (HeidiHan0000)
- 3a6ae851fcdc5eabe5a0737a4093f80c57184ff9 Fix formatting in /security/ docs (Steve Burnett)
- 8068e3674093ce146d3ebc51f57bb1aaa01b2373 Timeout reading delta tables after incremental updates with null values (#24920) (Miguel Blanco Godón)
- 560e0650775df26fabc37fe1843615b996d0e9bf Fix release note action with unescaped chars (Zac Blanco)
- c6a7a465f3d2ad85987127b2ac7f48c4729fda74 Add integer type to visitGenericLiteral in translator (mohsaka)
- 913115c2815591fc138e87743027986676a83494 [native] Make constant arg check optional in parseIndexLookupCondition (Zac Wen)
- 38f9ae6698d6cba4f513b8f1bb686e77043c074c [native] Allow empty file in table scan (Jimmy Lu)
- 6ba1e14379fe6873891e96e42fbcf6bfa03c058b [native] Move parseIndexLookupCondition out so it can be reused (Zac Wen)
- b7fc613f22a637d58cebde0ae1a2fcb05c84e6ca Use feature toggle for logging (Shang Ma)
- af1881b02336935c8cf87320c37ea79033151ad2 Update error classification for group by with lambdas (Xiao Du)
- 27e37d63f37fc115169878709126ca750f02aeee Add additional column metadata to event listener QueryOutputMetadata (Nidhin Varghese)
- 567d4dc528854e7a78ef4f4b385dd991973d7dc2 Add cosine_similarity function for two arrays (Amit Dutta)
- 0d3a2edd1858980948256189a98b6080178cf92a Update zookeeper version to fix CVE-2023-44981 (Shijin)
- 1a3a4f7e9d8d7bad088c8d6d16403364a876eeb3 [native] Separate Task start logic into a method. (Sergey Pershin)
- b7ef89cb188210713e0602c10235dbb576356258 Update decimal functions document (mecit-san)
- 816f3db1f0348efd69a2c54c771a9c0ff8e7851f [router] scheduler bug fixes and test enhancements (#24580) (Jayaprakash Sivaprasad)
- 56d860e17ad219548a73e7fe0882ac13bf17f9d1 refactor: Move MemoryManagerOptions inside MemoryManager step0, explicitly specify object type (#25050) (Ke Wang)
- 7368dd867f87654676d3ffc0b6b197b1c9ece6f7 [native] Export proper Task create time (Sergey Pershin)
- e5e09c418b946cda9f0b1fb952d4db859b53d26d Skip presto-main-base tests from test-other-modules (Anant Aneja)
- 0b7398d802ad4ffc8cb9dfe7774c3544c0948fbf Upgrade okio-jvm version & add presto-base-arrow-flight version in dependency management (Hazmi)
- 87059e57d95b7522a48d15f43299f4bdc6804a40 Extract WindowNode.Specification as a separate class (mohsaka)
- 8193075e7a30c6772bda0c294166212d52c62fbe [native] Add presto_protocol_arrow_flight.json to gitignore config (aditi-pandit)
- 47797edaa1b8d7a909b786adf444ae479436dc06 [native]Update task cursor usage and advance velox version (Xiaoxuan Meng)
- 60f1ba70c41d5153596d50c36f6bbd3fee363834 Add view text hash info to accessControlReferences (#24955) (Kevin Tang)
- a9a9baebd548e4e8fdb87bf3d27ed5714b16c6f9 [router] Use nanos for cluster health check  (#25043) (Anant Aneja)
- 4146f561e140bd26378bb037b9140be3967bec17 Improve empty TableScanNode warning in BaseSubfieldExtractionRewriter (#24667) (jkhaliqi)
- 0e0572e5da41e76dca4551a702b1616c46a1ef1b Update presto-docs/src/main/sphinx/presto_cpp/properties-session.rst (tanjialiang)
- 318f495bc1166d0ed1dfde409c35cbcd996b98d8 Update presto-docs/src/main/sphinx/presto_cpp/properties-session.rst (tanjialiang)
- a118825c40d833c8d9f6b81f927ae376c09cccb9 Update presto-docs/src/main/sphinx/presto_cpp/properties-session.rst (tanjialiang)
- d8d1d61268ed551cc7386a97fafc8efcdd92c25f Switch to integer based streaming aggregation output batch session (Jialiang Tan)
- a0562c8256a1f1ab3461d3737e8ad23f61e88204 Support reset all readers in startStripe() (Chen Yang)
- e936ad06e9e205df978ad74287a490f552870047 [native] Clean up code in PrestoToVeloxQueryPlan (Zac Wen)
- 9f689e91f2102536a9d3116a5855cfc38895cdff Add runtime metrics for task time on event loop and log slow execution (#25009) (Shang Ma)
- f7af3b5f272c8cbd78efe4a3be994e3f0e156cf3 Separate native IndexJoinRewriter from Java path (Zac Wen)
- 4caf30f756da7b660b78142633220677a98a3b26 Add operator < to ArrowColumnHandle protocol (Bryan Cutler)
- 9547eae0fa012111085e64ef0fa758301a2dce13 [native] Map Presto SOURCE_OUTER index join type to Velox LEFT (Zac Wen)
- 8fd33ae93a7029464c6141ae1e76ecd3b37c8d1c [native] Fix native-tests filepath (Pramod Satya)
- dde5c16533cbf5796568ffc2d40a7ccec6ad6416 Fix: Re-initialize sort key serializer for every new input added (Emily (Xuetong) Sun)
- b0b9c8f4b7cd6f0b6cb4c8525fe8974b24e9a7c5 Print IndexSourceNode table handle in query plan (Zac Wen)
- 60bbd2e2fbff8b40b471792d129457bf3383f2fd Add support for optional kafka SASL (Shahim Sharafudeen)
- e540ed92a1a28d70acd5c85ec872bab48b4fc093 Fix distributed sort parallelism for single node execution (Andrii Rosa)
- b563c8a9841608ba1c67cf7ebddb2499c140b0f5 [native] Track CPU & Memory overload in native worker. (Sergey Pershin)
- 6a89784e55fbe4cb8f3f275317188e72e8ed933b Add presto-base-arrow-flight version to root pom (#25006) (inf)
- 7424bf5a2138f9b10c9545f4f3497ac427ef6f32 [native] Support in filter for index join (Zac Wen)
- a6ecdb559b604a54480c5507df47b8dfd969c20c Add test coverage for SqlFunctionProperties equals (#25002) (XiaoDu)
- acb0321533cc99c0598e1bc2fbe4d6a1764fc120 Use S3 listObjectsV2 in PrestoS3FileSystem listPrefix (#24794) (Deepak Mehra)
- db701788360b21535ad0a4ca9152354a09e2c281 Upgrade plexus-utils and commons-beanutils (#24665) (Mariam AlMesfer)
- 54ff0a10aa6d6dd6f8cd310818844674829bcd13 Fix ARRAYS_OVERLAP function bug (Hazmi)
- 842a3eb36ec8bf9380a2e42f5061df79b00fb23a Fix compilation of NativeExecutionTypeRewrite (Zac Blanco)
- c2c35986309367e2d408098465da6f5a4c76f81f [native] Advance velox. (Amit Dutta)
- 931d4a69746f8104a81ff6188e38327a4a8bc91a Check Query integrity in Analyzer Util (#24927) (Kevin Tang)
- 6a71d6e67def1e0259ec4242124453114c0ebee5 Add NativeExecutionTypeRewrite (Zac Wen)
- 05b1df91924ae2dcba9dbdd16c9037fb58d2d84e Allow connector optimizer to apply to IndexSourceNode (Zac Wen)
- 10c586d25ded475c18a7b97aafbd40f530927e66 Improve failure message for QualifiedObjectName not 3 parts (Rebecca Schlussel)
- 1abad211d8f8cc67342a07cd6b2ae87e27d0f0bd Improve addColumnMasks efficiency (Bryan Cutler)
- 8f789ec23f9d114a5b22ecb0acd0012497a6d5f3 Fetch column masks in bulk (Bryan Cutler)
- 92c7602aceb1db2dac838bbf7e1f91f67be6f710 Allow returning multiple filters and masks (Bryan Cutler)
- 05906fb934673d655fa06f9bbeca8c7e69a462ec Disallow multiple masks on a given column (Bryan Cutler)
- a41eadcc275a029244dbef68819c32c3740706db Add support for column masking (Bryan Cutler)
- b03ee2c1129e517b6641bcf5fd8e7e6d8fc5b81d Add support for row filtering (Bryan Cutler)
- ebf7bb85a9f79772c4cc25dbaf7cb607598ace74 [Iceberg]Prefer `AppendFiles` over `RowDelta` in insert-only statement (wangd)
- 26e1b66f9baf6e81a5c2335faa114ef484fd89a9 [native] Add index join node protocol unit test (Zac Wen)
- 8c9436f0b9910d81780b32f84cea9d88bdbd9280 [native] Support between filter for index join (Zac Wen)
- 93a4521cf970141f8543730e0aee28d78749f06a Add system configs to query configs mapping for requestDataSizesMaxWaitSec (#24977) (Heidi Han)
- 1143ce4878dba3b9664d19282079fe019b24db0d [sidecar] Fix sidecar-coordinator HTTPS communication and handle IPv6 in URL generation (Pratik Joseph Dabre)
- e5998e84053f7ba9cb81ae2be7efd91339d0f646 Add less lock hungry AsyncQueue#offerAll (James Petty)
- 86d05e7d487f3fcb2eb5fe39cde1248d5bcb94d4 Restore exception handling for IllegalArgumentException during type resolution (Pratik Joseph Dabre)
- 7a97ef8923c41bdb81bf2f50d14fe89918e08e2d Use VectorFuzzer for BinarySortableSerializer test (#24954) (Emily (Xuetong) Sun)
- ee6bc00c62b370967a580aeb23db5ae3a72d862c Revise formatting in iceberg.rst (Steve Burnett)
- 2d7abbc3d9c0a3e7a3b45a4bec4d9efdc1906356 [native] Fix blank HTTP host header in requests (Zac Blanco)
- da477e21517701b261165955743220b3228339d2 Add coordinator health checks and counter jmx metrics to presto router (Auden Woolfson)
- a6f000de0f11d88dbc3ad4ef3409295bc610e27a fix: TDigest Functions Null Input Behavior (#24969) (Natasha Sehgal)
- 32d39526e996aa26e5fcf7e8a153764bab5cba90 [native] Pin gperf to 3.1 (Deepak Majeti)
- ed70be3358cf1d65a126f4224bfb7bd9580c88a7 Add filter to IndexJoinNode protocol (Zac Wen)
- dd4e5ef19855738ddf677a1228b8688bf70aaae8 Fix native functional test (Joe Abraham)
- 902c07983646728d7d5157bd1de8c44a810d54dd Add filter to IndexJoinNode (Zac Wen)
- 33ddf2fd88601375dbcc957426a2399060316d9b Support sorted shuffle write in Sapphire-Velox stack (Emily (Xuetong) Sun)
- 636a75da1c846f8de2635d537e56bb1fc5c7f254 Add configuration to specify metastore catalog name (Anurag Dwivedi)
- 2f29ba927fdc965414039c73a8c304904849b060 Add a BinarySortableSerializer to Sapphire-Velox (#24739) (Emily (Xuetong) Sun)
- 34ef2c7e34b25ebc029c3e0a86646205218df408 Fix rollback after statement fail in non-autocommit transaction (wangd)
- 0510d1d74ef87e3e52ff4b617e02db2f6e8f3b06 use "when" (ebonnal)
- 7d2d1a0b1e9bf3aafd9f6b7b11cf98792154c03e Clarify in the documentation that `ELEMENT_AT` returns NULL when out of bounds (ebonnal)
- 240557b5c140e67f36abb432ec0654dcaee7e356 [native] Add session property for eager streaming aggregation flush (Jialiang Tan)
- 4e14711ace33f542217cf58148c6e92177594c65 Fix presto-native-tests CI (Pramod Satya)
- 845275c14ed0f477f677d2a850b53ebb795293cd Refactor MultiJoinNode into a separate class (Haritha Koloth)
- 6e6c787cacb6e09327ff997555cdaeb5480d6d73 Add planner rule GroupInnerJoinsByConnectorRuleSet (Haritha Koloth)
- 1cdd77d7f295a2406608817c235d44698ecf0877 SPI Changes for Join pushdown (Haritha Koloth)
- 29a487548bcdb94a7ca5a35a07c25296f15b7aa1 Add release note check action (#24855) (Zac Blanco)
- 906ebcdc6e01da29e1f27dc3fb671129125f87ce Refactor out the duplicate definition of method `isEntireColumn` (wangd)
- b2919faba781a0aeea2eb52d44bd807579fdcd41 [native] Save 1 memcpy in parsing message body (#24941) (Yuanda (Yenda) Li)
- e76f5a5cea132acf424b939c8fcdd1a8435422cf [native] Advance velox. (Amit Dutta)
- 40e1201251279151fbbe284520bb5d6031e655c9 [native] Make PeriodicMemoryChecker member of PrestoServer (Sergey Pershin)
- fb6d9af9bfcf2973a102a32090d3b1587768fe86 [native] Minor refactor in http filter registration. (Amit Dutta)
- 36198ee5b258e52ebbbfe6c46171b3a58ca60257 Fix failing CI: pin JVM 8 to 8.0.442 (Zac Blanco)
- 4f8429c0ab6c06d3592f39e496946297ecba9e96 Update presto-docs/src/main/sphinx/presto_cpp/features.rst (Xin Zhang)
- 7fb6a6ebce5aa4ea689eedf639996cb4eb81a865 Update presto-docs/src/main/sphinx/presto_cpp/features.rst (Xin Zhang)
- 813497264879845a5de82f276b21935cd379b5b5 [native] Add S3 metrics reporting (Xin Zhang)
- 2faef71c511268c69c4328f37980b57b6fb2c56c Upgrade sqlserver driver to version 12.8.1 (lukmanulhakkeem)
- 729508ff912ac8bce2e6c5c8189403036756eded Fix TDigest::scale() to update sum member. (Sergey Pershin)
- a33f73def6f682c48a09a1ba4c78275cf527da8c Re-introduce improving the merging of operator stats (#24921) (Shang Ma)
- 8bcc971f345f2a620e7bfecae6720806fc9aacb7 Add factorial implementation, documentation and tests (Samuel Majoros)
- ffd582430870fc40f815003c23e8555758262f1f [native] Advance velox. (Amit Dutta)
- c8874d61fb3738714e0a41c2283f45c3bb25fbd2 [presto] Add state filter to the queryState resource (#24856) (Prashant Golash)
- afdd1c7902daf94b9b0116a2fb9a29c9bf7a1fb0 Add shared-arbitrator.memory-pool-abort-capacity-limit into property registry (#24915) (Jialiang Tan)
- 3fdeab48ea1ae14845caa103b9226dbbe37a659d Update deployment.rst (Akinori Musha)
- 36664c38f644727590cf20b40c1ad91e5ef9ca06 Add jaro-winkler implementation, documentation and tests (Samuel Majoros)
- 411def9e445fa455febe737f39e6f656212a69a7 Make EquiJoinClause fields in IndexJoinNode compatible with protocol (Zac Wen)
- a650ab644d5f8ba9b5c0e57d77fee84db4317b04 Arrow Flight tests use open port for server (Bryan Cutler)
- beec0e487378bd21206e4e1136cc55066d47dccf Fix confusing OrcCorruptionException thrown by ORC metadata reader (#24897) (Serge Druzkin)
- 7820553c6a5b1d45bf65a9de61fc1c7c9832172e [native] Fix macos CMake failure (Deepak Majeti)
- ba44ea5c6e6d23fd45251a28cf15a1272c65f5b2 Remove redundant table layout call (Pradeep Vaka)
- 4bdd0a3568b8b17f93c8356b0424bd563338cc88 [native] Add ConnectorIndexHandle to ConnectorProtocolTemplate (Zac Wen)
- d9d45cbffd9f92a2f7076fdb0240e35de5c148cc [native] Add protocol generation and incremental build in debug CI build (Christian Zentgraf)
- 432c9aa72b187b7b1d238efad18e319b92f50e90 Upgrade elasticsearch dependency to 7.17.27 (Hazmi)
- ddba4bafbd8fc1161e9cce2cf95d39b7c33031ed Remove DeleteScanInfo (#24857) (Shelton Cai)
- a972bba874890115d606de4155c5bb5b79de669f Add distinct semi join plan optimization (Jialiang Tan)
- 6ff63755779c3d5dc16a764f73e9b08abf0f1ece [native] Add longVariableConstraints to function metadata (Pratik Joseph Dabre)
- 5c637966fe62de23f5f357a714836c0327f893da Fix sensitive data disclosure in logs (Nivin C S)
- 899f740a311e94ac7f60aff6e2e0aff3f643a0e8 Add github action to publish artifacts for presto stable release (#24821) (Li Zhou)
- aac1155a6952bfb2a03a599cc61b72a6368df4d5 Add longest common prefix implementation, documentation and tests (Samuel Majoros)
- 341129eca940800c3be8c9cbbbe25de93b5fd472 [native] Add sidecar and sidecar plugin documentation (Pramod Satya)
- 7eb39152fd00526a94c775f6495205ef936eba49 [native] Add protocol for index lookup join plan (Zac Wen)
- 549101ddc7910a16ced2f715b994a503cc38e70e [native] Advance Velox (Zac Wen)
- d756ade331eb53be83e29a676a23ef4cc05e6abb use com.facebook.airlift:security in presto-hive-metastore (Zac Blanco)
- 3b9e0f153310cdfc138dab8ca63fdeccecc05a2c Add support for S3 WebIdentity authentication (Sayari Mukherjee)
- fb095805e8413ea1755c26d5b5dbc4e4a6d2682a doc on hive csv limitations (Najib Adan)
- 2d49f44c50ecd8ecb715c973b155155a2e540423 Add memory pool debug regex (Jialiang Tan)
- 7196add26bfb21e692b878d59d782c0895265a41 Add documentation for Iceberg support in PrestoCPP (Reetika Agrawal)
- 14a69e9b44c37f34caca6d09fd57d63cdedbf4ce Reuse JoinType in IndexJoinNode (Zac Wen)
- 02a65c0b6f2ed9027b44f657cc87916352c230de Reintroduced json_extract to generate canonicalized output (#24879) (XiaoDu)
- 455f84715167b0fe6ef416fd4c2185d87168f140 [native] Add tests for UUID type (aditi-pandit)
- 832aefbfd86a1ad2497a17bcdece2d4b27f20174 Changes to enable ssl/tls in hms (Shijin K)
- ab039786cd35a955415ccd9c68cb06aa2c1cfde5 [native] test modification. (Amit Dutta)
- 3a4ff9028f0fae39b41038293dbcfde8bcc56191 Fix error when describing a nonexistent table (Elbin Pallimalil)
- 31d3e2e5e4fe11ae9347ae49078e9d09118b10c0 [native] Advance velox. (Amit Dutta)
- 574f832328f67fe7ca8f69bad03cfc3ebb3d6350 [native] Add a test group for async data cache e2e tests. (Amit Dutta)
- c87529695ff0ff2375e52d46c9a7149137831537 Add various compressionCodec in PagesSerdeFactory (Xin Zhang)
- 682bf7e1f1a1d873268da3009fecb8bdf8227261 Refactor compressionEnabled to compressionCodec in PagesSerdeFactory (Xin Zhang)
- 162d632bc40d13265963b5a080f73e4e31e31d98 Pass full session to avoid Unknown connector errors (Denodo Research Labs)
- c8566b42ec3badece0ccd2ce9029f231fd8a8dd1 revert json_extract to Produce Canonicalized Output (#24864) (XiaoDu)
- 940a92afa4bebf5acfd4bcd4e15736f7f042e158 Add team-velox as code owners for presto-native-sidecar-plugin and presto-native-tests modules (aditi-pandit)
- 80e765c35be4e711d9f902215fecf992b6a13292 [native] Fix presto protocol generation for presto-main-base module changes (Zac Blanco)
- 040d925eac741f1c3aacb880957fcd30f2141001 [native] Fix v1/operation/task/getDetail (Deepak Majeti)
- fb4e489e439ff6fadaf143ce9798a3572d3393d0 [native] Advance Velox (aditi-pandit)
- 45e0e21ef65a28380d984b36200075566fe2830d [native] Remove register-test-functions worker config (Pramod Satya)
- d16d9d7d03c89e67300a91f70fda7580766d9b6f Add Iceberg ManifestFile cache invalidation procedure (Reetika Agrawal)
- f6962c7adceeb1361aebf428b8051639b90f8d4b Add Iceberg StatisticsFile cache invalidation procedure (Reetika Agrawal)
- b0286c5a8a448919cd29619d7f2d6ce64cfbbb87 Upgrade the MySQL to version 9.2.0 (namya28)
- 168caf0f41a472b2dbce7bdc730fb2de3bbe5b22 [native] Remove presto_types and presto_connectors cyclic dependency (Deepak Majeti)
- c9ee8a7e1f5e847a47f4546bf1410ff086da0a53 [native] Include a header for forward declaration (Zac Wen)
- c6bbe07247b855166f3c2c998dadae19c6a4bb3d Include errors for presto-ui dependency install (Deepak Majeti)
- 43a1662e4f736310756e33414cd9ae63f3c22282 Support bucket transform for columns of type TimeType in Iceberg table (wangd)
- 9abb67b35c6a0c3e1b67fc301eae1d0e763a0899 OperatorStats overflow fix (Natasha Sehgal)
- f7d99dc9e3486e4446e0daf27070c63e44c8bc69 Add test scope back to presto-tpch in presto-main (Zac Blanco)
- 03e535c36a23818e6240442247ec7d60be57a0c9 Remove duplicated code in ValuesMatcher.java (Xin Zhang)
- f87e3218770c5fe2d534f3d5a2ced0200ff2c70a [native] Advance velox. (Amit Dutta)
- 79742a91eacfd70fb25a0fa57ca659f8b9f0552c Remove negative check on 'outputDataSizeInBytes' stat. (Sergey Pershin)
- 6e17a0358fdb3b33d69c4ca9714e45cb0f95eb75 Add Jmx metrics information for caching in Iceberg (Reetika Agrawal)
- cd4a9a08c51d4e74b5b653249c1df76faf2abf33 [presto][ui] Display queued queries per subgroup RG (#24830) (Prashant Golash)
- f9faf6af1508750a48a1452b739e8569d057ab56 Fix: RedisProviderPlugin cannot be instantiated using reflection in PluginManager (Heng Xiao)
- 20ea3cc16eed97f42fbeb485ddf7fd58e3e0c3c2 squash this into one commit if needed (Jacob Khaliqi)
- 61104afe53a0262bfb28c868caa6fccee1e181c6 Updated deprecated hadoop properties (Jacob Khaliqi)
- d22d3c244840673546ccdebcd704814382af2462 Add DeleteNode translation to TableWriteNode in Velox query plan (#24772) (Gary Helmling)
- f8b8484527d94aa2a4e5b17819a5feef0fecf6f4 [native] Advance velox. (Amit Dutta)
- e51880202f746b1f5a0fe751e5d4c7fcd13d537e Run presto-native-tests with DWRF and PARQUET (Pramod Satya)
- 4dc826037d6c1d0d526cce61984e3c91a4050a79 Add Presto C++ topic to connector/base-arrow-flight.rst (Steve Burnett)