### PR TITLE
Add release notes for 0.294

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    Release-0.294 [2025-07-04] <release/release-0.294>
     Release-0.293 [2025-05-29] <release/release-0.293>
     Release-0.292 [2025-03-28] <release/release-0.292>
     Release-0.291 [2025-01-27] <release/release-0.291>

--- a/presto-docs/src/main/sphinx/release/release-0.294.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.294.rst
@@ -1,0 +1,112 @@
+=============
+Release 0.294
+=============
+
+**Highlights**
+==============
+
+**Details**
+===========
+
+General Changes
+_______________
+* Fix PushdownSubfields optimizer to enable subfield pushdown for maps which is accessed with negative keys. `#25445 <https://github.com/prestodb/presto/pull/25445>`_
+* Fix error classification for unsupported array comparison with null elements, converting it as a user error. `#25187 <https://github.com/prestodb/presto/pull/25187>`_
+* Fix subfield pushdown arg index for scalar functions to support selecting whole struct column. `#25471 <https://github.com/prestodb/presto/pull/25471>`_
+* Fix: Revert the Write mapping support. `#25369 <https://github.com/prestodb/presto/pull/25369>`_
+* Fix: Revert the move of boostrap fromm presto-main to presto-bytecode. `#25260 <https://github.com/prestodb/presto/pull/25260>`_
+* Improve `MinMaxByToWindowFunction` optimizer to cover cases where aggregation is on both map/array and non map/array types. `#25435 <https://github.com/prestodb/presto/pull/25435>`_
+* Improve query resource usage by enabling subfield pushdown for :func:`map_filter` when selected keys are constants. `#25451 <https://github.com/prestodb/presto/pull/25451>`_
+* Improve query resource usage by enabling subfield pushdown for :func:`map_subset` when the input array is a constant array. `#25394 <https://github.com/prestodb/presto/pull/25394>`_
+* Improve remove map cast rule to cover map_subset function. `#25395 <https://github.com/prestodb/presto/pull/25395>`_
+* Improve semi join performance for large filtering tables. `#25236 <https://github.com/prestodb/presto/pull/25236>`_
+* Add a function to Constraint to return the input arguments for the predicate. `#25248 <https://github.com/prestodb/presto/pull/25248>`_
+* Add a new optimization `MinMaxByToWindowFunction` to rewrite min_by/max_by aggregations with row_number window function. `#25190 <https://github.com/prestodb/presto/pull/25190>`_
+* Add a session property to disable the ReplicateSemiJoinInDelete optimizer. `#25256 <https://github.com/prestodb/presto/pull/25256>`_
+* Add a session property to have HBO estimate plan node output size using individual variables. `#25400 <https://github.com/prestodb/presto/pull/25400>`_
+* Add an optimizer to add distinct aggregation on build side of semi join. `#25238 <https://github.com/prestodb/presto/pull/25238>`_
+* Add mixed case support for schema and table names. `#24551 <https://github.com/prestodb/presto/pull/24551>`_
+* Add property ```native_query_memory_reclaimer_priority```  which controls which queries are killed first when a worker is running low on memory. Higher value means lower priority to be consistent with velox memory reclaimer's convention. `#25325 <https://github.com/prestodb/presto/pull/25325>`_
+* Add pushdownSubfieldArgIndex parameter to ComplexTypeFunctionDescriptor for subfield optimization during query planning. `#25175 <https://github.com/prestodb/presto/pull/25175>`_
+* Adds aggregation tests from ``presto-tests`` to run with native query runner in ``presto-native-tests``. `#24809 <https://github.com/prestodb/presto/pull/24809>`_
+* Replace the parameters in router schedulers to use `RouterRequestInfo` to get the URL destination. `#25244 <https://github.com/prestodb/presto/pull/25244>`_
+* ... `#25223 <https://github.com/prestodb/presto/pull/25223>`_
+* ... `#25223 <https://github.com/prestodb/presto/pull/25223>`_
+* Extend  MergePartialAggregationsWithFilter to work for queries where all aggregations have mask. `#25171 <https://github.com/prestodb/presto/pull/25171>`_
+* Move UnnestNode to SPI, make it available in collector optimizer. `#25317 <https://github.com/prestodb/presto/pull/25317>`_
+* Update ProtocolToThrift files to be generated for cpp thrift serde. `#25162 <https://github.com/prestodb/presto/pull/25162>`_
+* Update router UI to eliminate vulnerabilities. `#25206 <https://github.com/prestodb/presto/pull/25206>`_
+
+General Change Changes
+______________________
+* Improve memory usage in writer by feeing unused buffers. `#23724 <https://github.com/prestodb/presto/pull/23724>`_
+
+Prestissimo (Native Execution) Changes
+______________________________________
+* Fix Native Plan Checker for CTAS and Insert queries. `#25115 <https://github.com/prestodb/presto/pull/25115>`_
+* Fix PrestoExchangeSource 400 Bad Request by adding the "Host" header. `#25272 <https://github.com/prestodb/presto/pull/25272>`_
+
+Prestissimo (native Execution) Changes
+______________________________________
+* Improve memory usage in PartitionAndSerialize Operator by pre-determine the serialized byte size of a given sort key at 'rowId'. This allows PartitionAndSerialize Operator to pre-allocated the exact output buffer size needed for serialization, avoid wasted memory allocation. User should expect lower memory usage and up to 20% runtime increase when serializing a sort key. `#25393 <https://github.com/prestodb/presto/pull/25393>`_
+* Add BinarySortableSerializer::serializedSizeInBytes method that returns the serialized byte size of a given input row at 'rowId'. This allows us to pre-allocated the exact output buffer size needed for serialization, avoiding wasted memory space. `#25359 <https://github.com/prestodb/presto/pull/25359>`_
+* Add sidecar in presto-native-tests module. `#25174 <https://github.com/prestodb/presto/pull/25174>`_
+
+Security Changes
+________________
+* Upgrade commons-beanutils dependency to address 'CVE-2025-48734  <https://github.com/advisories/GHSA-wxr5-93ph-8wr9>'. `#25235 <https://github.com/prestodb/presto/pull/25235>`_
+* Upgrade kafka to 3.9.1 in response to `CVE-2025-27817 <https://github.com/advisories/GHSA-vgq5-3255-v292>`_. :pr:`25312`. `#25312 <https://github.com/prestodb/presto/pull/25312>`_
+
+JDBC Driver Changes
+___________________
+* Improve type mapping API to add WriteMapping functionality. `#25124 <https://github.com/prestodb/presto/pull/25124>`_
+* Add mixed case support related catalog property in JDBC connector ``case-sensitive-name-matching``. `#24551 <https://github.com/prestodb/presto/pull/24551>`_
+
+Hive Connector Changes
+______________________
+* Fix an issue while accessing Symlink tables. `#25307 <https://github.com/prestodb/presto/pull/25307>`_
+* Fix incorrectly ignoring computed table statistics in `ANALYZE`. `#24973 <https://github.com/prestodb/presto/pull/24973>`_
+* Update default value of `hive.copy-on-first-write-configuration-enabled` to false (:issue:`25404`). `#25420 <https://github.com/prestodb/presto/pull/25420>`_
+
+Iceberg Connector Changes
+_________________________
+* Fix error querying ``$data_sequence_number`` metadata column for table with equality deletes. `#25293 <https://github.com/prestodb/presto/pull/25293>`_
+* Fix the remove_orphan_files procedure after deletion operations. `#25220 <https://github.com/prestodb/presto/pull/25220>`_
+* Add ``iceberg.delete-as-join-rewrite-max-delete-columns`` configuration property and ``delete_as_join_rewrite_max_delete_columns`` session property to control when equality delete as join optimization is applied. The optimization is now only applied when the number of equality delete columns is less than or equal to this threshold (default: 400). Setting this to 0 disables the optimization. See :doc:`/connector/iceberg` for details. `#25462 <https://github.com/prestodb/presto/pull/25462>`_
+* Add support for ``$delete_file_path`` metadata column. `#25280 <https://github.com/prestodb/presto/pull/25280>`_
+* Add support for ``$deleted`` metadata column. `#25280 <https://github.com/prestodb/presto/pull/25280>`_
+* Add support of ``rename view`` for Iceberg connector when configured with ``REST`` and ``NESSIE``. `#25202 <https://github.com/prestodb/presto/pull/25202>`_
+* Deprecate ``iceberg.delete-as-join-rewrite-enabled`` configuration property and ``delete_as_join_rewrite_enabled`` session property. Use ``iceberg.delete-as-join-rewrite-max-delete-columns`` instead. `#25462 <https://github.com/prestodb/presto/pull/25462>`_
+
+JDBC Connector Changes
+______________________
+* Add skippable-schemas config option for jdbc connectors. `#24994 <https://github.com/prestodb/presto/pull/24994>`_
+
+Mongodb Connector Changes
+_________________________
+* Add support for Json type in MongoDB. `#25089 <https://github.com/prestodb/presto/pull/25089>`_
+
+Mysql Connector Changes
+_______________________
+* Add support for mixed-case in MySQL. It can be enabled by setting ``case-sensitive-name-matching=true`` configuration in the catalog configuration. `#24551 <https://github.com/prestodb/presto/pull/24551>`_
+
+Redshift Connector Changes
+__________________________
+* Fix Redshift connector runtime failure due to missing dependency on ``com.amazonaws.util.StringUtils``. Add ``aws-java-sdk-core`` as a runtime dependency to support Redshift JDBC driver (v2.1.0.32) which relies on this class for metadata operations. `#25265 <https://github.com/prestodb/presto/pull/25265>`_
+
+Documentation Changes
+_____________________
+* Add :ref:`connector/hive:Avro Configuration Properties` to Hive Connector documentation. `#25311 <https://github.com/prestodb/presto/pull/25311>`_
+
+Arrow Flight Connector Template Changes
+_______________________________________
+* Added support for mTLS authentication in Arrow Flight client. `#25179 <https://github.com/prestodb/presto/pull/25179>`_
+
+Router Changes
+______________
+* Add a new custom router scheduler plugin, the `Presto Plan Checker Router Scheduler Plugin <https://github.com/prestodb/presto/tree/master/presto-plan-checker-router-plugin/README.md>`_. `#25035 <https://github.com/prestodb/presto/pull/25035>`_
+
+**Credits**
+===========
+
+Ajay Kharat, Amit Dutta, Anant Aneja, Andrew Xie, Andrii Rosa, Arjun Gupta, Auden Woolfson, Beinan, Chandra Vankayalapati, Chandrashekhar Kumar Singh, Chen Yang, Christian Zentgraf, Deepak Majeti, Denodo Research Labs, Elbin Pallimalil, Emily (Xuetong) Sun, Facebook Community Bot, Feilong Liu, Gary Helmling, Hazmi, HeidiHan0000, Henry Edwin Dikeman, Jalpreet Singh Nanda (:imjalpreet), Jialiang Tan, Joe Abraham, Ke Wang, Kevin Tang, Li Zhou, Mahadevuni Naveen Kumar, Mariam Almesfer, Natasha Sehgal, NivinCS, Ping Liu, Pramod Satya, Pratik Joseph Dabre, Rebecca Schlussel, Sebastiano Peluso, Sergey Pershin, Sergii Druzkin, Shahim Sharafudeen, Shakyan Kushwaha, Shang Ma, Shelton Cai, Soumya Duriseti, Steve Burnett, Thanzeel Hassan, Timothy Meehan, Wei He, XiaoDu, Xiaoxuan, Yihong Wang, Ying, Zac Blanco, Zac Wen, Zhichen Xu, Zhiying Liang, Zoltan Arnold Nagy, aditi-pandit, jay.narale, lingbin, martinsander00, mima0000, mohsaka, namya28, pratyakshsharma, vhsu14, wangd


### PR DESCRIPTION
# Missing Release Notes
## Arjun Gupta
- [ ] https://github.com/prestodb/presto/pull/25210 Add session property for passing query client timeout value (Merged by: Arjun Gupta)

## Gary Helmling
- [ ] https://github.com/prestodb/presto/pull/25284 Make rowid optional in DELETE query plan (Merged by: Gary Helmling)

## Jialiang Tan
- [ ] https://github.com/prestodb/presto/pull/25271 [native] Add remaining from spill header to http shuffle API (Merged by: tanjialiang)
- [ ] https://github.com/prestodb/presto/pull/25239 [native] Make PeriodicMemoryChecker::stop() virtual (Merged by: tanjialiang)

## Shakyan Kushwaha
- [ ] https://github.com/prestodb/presto/pull/24854 [native] Allow options for wget and tar commands during setup Part:2 (Merged by: Deepak Majeti)

## Zhichen Xu
- [ ] https://github.com/prestodb/presto/pull/25409 Add squared Euclidean distance (l2_squared) in java implementation (Merged by: feilong-liu)

## duhow
- [ ] aa7d196be475316b01922b20a643f1e0a981f8b2 pass TERM signal to application
- [ ] 9ded1b08ef922bbc2bff01049fae2d7ffe09bbef mount installer package instead of copy
- [ ] 7365d0c6fe1d34ca033d38121c7b0efdb9bd6395 reorder layers to install base apps first
- [ ] 855f53f3d239a8ce456b745136dda94b3afe4191 create folder recursive, create data volume
- [ ] 2645fcd9196d1539d14e03dc91cba06c6b7f1509 cache dnf installer
- [ ] 8425dab3ce9c306a93da41276acc962b47567e5f chmod executable jar on copy

# Extracted Release Notes
- #23724 (Author: Chen Yang): Reduce memory usage in writer by freeing unused buffers
  - Improve memory usage in writer by feeing unused buffers.
- #24551 (Author: NivinCS): Mixed case identifier support
  - Add mixed case support for schema and table names.
  - Add mixed case support related catalog property in JDBC connector ``case-sensitive-name-matching``.
  - Add support for mixed-case in MySQL. It can be enabled by setting ``case-sensitive-name-matching=true`` configuration in the catalog configuration.
- #24809 (Author: Pramod Satya): [native] Add `TestAggregations` to native-tests
  - Adds aggregation tests from ``presto-tests`` to run with native query runner in ``presto-native-tests``.
- #24973 (Author: Denodo Research Labs): Fix ANALYZE when Hive partition has non-canonical value
  - Fix incorrectly ignoring computed table statistics in `ANALYZE`.
- #24994 (Author: Hazmi): Add config option to skip system schemas in JDBC connectors
  - Add skippable-schemas config option for jdbc connectors.
- #25035 (Author: Pratik Joseph Dabre): Add a new custom router scheduler plugin : `presto-plan-checker-router-plugin`
  - Add a new custom router scheduler plugin, the `Presto Plan Checker Router Scheduler Plugin <https://github.com/prestodb/presto/tree/master/presto-plan-checker-router-plugin/README.md>`_.
- #25089 (Author: Mariam Almesfer): Add support for json type in MongoDB
  - Add support for Json type in MongoDB.
- #25115 (Author: Timothy Meehan): Fix Native Plan Checker for CTAS and Insert queries
  - Fix Native Plan Checker for CTAS and Insert queries.
- #25124 (Author: Hazmi): Write mapping support
  - Improve type mapping API to add WriteMapping functionality.
- #25162 (Author: vhsu14): Generate ProtocolToThrift files through make and commit
  - Update ProtocolToThrift files to be generated for cpp thrift serde.
- #25171 (Author: Feilong Liu): Extend filtered aggregation optimizer to support only masked partial aggregation cases
  - Extend  MergePartialAggregationsWithFilter to work for queries where all aggregations have mask.
- #25174 (Author: Pratik Joseph Dabre): [native] Enable sidecar in presto-native-tests module
  - Add sidecar in presto-native-tests module.
- #25175 (Author: Kevin Tang): Add function metadata ability to push down struct argument in optimizer
  - Add pushdownSubfieldArgIndex parameter to ComplexTypeFunctionDescriptor for subfield optimization during query planning.
- #25179 (Author: Elbin Pallimalil): Add support for mTLS authentication in Arrow Flight client
  - Added support for mTLS authentication in Arrow Flight client.
- #25187 (Author: Zhiying Liang): Fix error classification for array with null elements
  - Fix error classification for unsupported array comparison with null elements, converting it as a user error.
- #25190 (Author: Feilong Liu): Add optimizer to convert min_by/max_by to row number function
  - Add a new optimization `MinMaxByToWindowFunction` to rewrite min_by/max_by aggregations with row_number window function.
- #25202 (Author: wangd): [Iceberg]Support rename view on Rest catalog and Nessie catalog
  - Add support of ``rename view`` for Iceberg connector when configured with ``REST`` and ``NESSIE``.
- #25206 (Author: Auden Woolfson): Forward fit router UI security fixes
  - Update router UI to eliminate vulnerabilities.
- #25220 (Author: Denodo Research Labs): Fix procedure remove_orphan_files with DELETES
  - Fix the remove_orphan_files procedure after deletion operations.
- #25223 (Author: Auden Woolfson): Share code between router ui and presto ui
  - ...
  - ...
- #25235 (Author: Shahim Sharafudeen): Fix vulnerability issue in commons-beanutils to address CVE-2025-48734
  - Upgrade commons-beanutils dependency to address 'CVE-2025-48734  <https://github.com/advisories/GHSA-wxr5-93ph-8wr9>'.
- #25236 (Author: Andrii Rosa): [native] Improve semi join parallelism
  - Improve semi join performance for large filtering tables.
- #25238 (Author: Feilong Liu): Add an optimizer to add distinct below build side of semi join
  - Add an optimizer to add distinct aggregation on build side of semi join.
- #25244 (Author: Pratik Joseph Dabre): Use RouterRequestInfo in router schedulers to get the URL destination
  - Replace the parameters in router schedulers to use `RouterRequestInfo` to get the URL destination.
- #25248 (Author: Feilong Liu): Optimize partition value evaluation in filter pushdown
  - Add a function to Constraint to return the input arguments for the predicate.
- #25256 (Author: Feilong Liu): Add a session property to disable ReplicateSemiJoinInDelete optimizer
  - Add a session property to disable the ReplicateSemiJoinInDelete optimizer.
- #25260 (Author: Shelton Cai): Revert #25245 Move Bootstrap.class to presto-bytecode to avoid duplicate definitions 
  - Fix: Revert the move of boostrap fromm presto-main to presto-bytecode.
- #25265 (Author: Ajay Kharat): Add aws-java-sdk-core as runtime dependency for Redshift JDBC driver
  - Fix Redshift connector runtime failure due to missing dependency on ``com.amazonaws.util.StringUtils``. Add ``aws-java-sdk-core`` as a runtime dependency to support Redshift JDBC driver (v2.1.0.32) which relies on this class for metadata operations.
- #25272 (Author: Deepak Majeti): [native] Add header "Host" to PrestoExchangeSource
  - Fix PrestoExchangeSource 400 Bad Request by adding the "Host" header.
- #25280 (Author: Andrew Xie): [Iceberg] Add support for $deleted and $delete_file_path metadata columns
  - Add support for ``$deleted`` metadata column.
  - Add support for ``$delete_file_path`` metadata column.
- #25293 (Author: Andrew Xie): [Iceberg] Fix querying data_sequence_number with equality deletes
  - Fix error querying ``$data_sequence_number`` metadata column for table with equality deletes.
- #25307 (Author: Jalpreet Singh Nanda (:imjalpreet)): Fix an issue while accessing Symlink tables
  - Fix an issue while accessing Symlink tables.
- #25311 (Author: martinsander00): Add Avro Configuration Properties to Hive connector docs
  - Add :ref:`connector/hive:Avro Configuration Properties` to Hive Connector documentation.
- #25312 (Author: namya28): upgrade kafka version to 3.9.1 in response to CVE-2025-27817
  - Upgrade kafka to 3.9.1 in response to `CVE-2025-27817 <https://github.com/advisories/GHSA-vgq5-3255-v292>`_. :pr:`25312`.
- #25317 (Author: Feilong Liu): Move UnnestNode to SPI and add to collector optimizer
  - Move UnnestNode to SPI, make it available in collector optimizer.
- #25325 (Author: Chandrashekhar Kumar Singh): [native] Add native memory pool reclaimer priority
  - Add property ```native_query_memory_reclaimer_priority```  which controls which queries are killed first when a worker is running low on memory. Higher value means lower priority to be consistent with velox memory reclaimer's convention.
- #25359 (Author: Emily (Xuetong) Sun): Add output size calculation to BinarySortableSerializer
  - Add BinarySortableSerializer::serializedSizeInBytes method that returns the serialized byte size of a given input row at 'rowId'. This allows us to pre-allocated the exact output buffer size needed for serialization, avoiding wasted memory space.
- #25369 (Author: Sebastiano Peluso): Revert #25124 Write mapping support 
  - Fix: Revert the Write mapping support.
- #25393 (Author: Emily (Xuetong) Sun): PartitionAndSerialize Operator: Allocate keyOutputBuffer with pre-determined size
  - Improve memory usage in PartitionAndSerialize Operator by pre-determine the serialized byte size of a given sort key at 'rowId'. This allows PartitionAndSerialize Operator to pre-allocated the exact output buffer size needed for serialization, avoid wasted memory allocation. User should expect lower memory usage and up to 20% runtime increase when serializing a sort key.
- #25394 (Author: Feilong Liu): Enable subfield pushdown for map_subset function
  - Improve query resource usage by enabling subfield pushdown for :func:`map_subset` when the input array is a constant array.
- #25395 (Author: Feilong Liu): Extend remove map cast rule to cover map_subset function
  - Improve remove map cast rule to cover map_subset function.
- #25400 (Author: Feilong Liu): Add an option to have HBO return output size with individual variable size
  - Add a session property to have HBO estimate plan node output size using individual variables.
- #25420 (Author: Jalpreet Singh Nanda (:imjalpreet)): Disable CopyOnFirstWriteConfiguration config property by default
  - Update default value of `hive.copy-on-first-write-configuration-enabled` to false (:issue:`25404`).
- #25435 (Author: Feilong Liu): Extend max_by/min_by optimization to mix of array/map/scalar type
  - Improve `MinMaxByToWindowFunction` optimizer to cover cases where aggregation is on both map/array and non map/array types.
- #25445 (Author: Feilong Liu): Enable subfield pushdown for map when key is negative
  - Fix PushdownSubfields optimizer to enable subfield pushdown for maps which is accessed with negative keys.
- #25451 (Author: Feilong Liu): Extend subfield pushdown to handle map_filter
  - Improve query resource usage by enabling subfield pushdown for :func:`map_filter` when selected keys are constants.
- #25462 (Author: Timothy Meehan): Add max column config and session properties to equality delete as jo…
  - Add ``iceberg.delete-as-join-rewrite-max-delete-columns`` configuration property and ``delete_as_join_rewrite_max_delete_columns`` session property to control when equality delete as join optimization is applied. The optimization is now only applied when the number of equality delete columns is less than or equal to this threshold (default: 400). Setting this to 0 disables the optimization. See :doc:`/connector/iceberg` for details.
  - Deprecate ``iceberg.delete-as-join-rewrite-enabled`` configuration property and ``delete_as_join_rewrite_enabled`` session property. Use ``iceberg.delete-as-join-rewrite-max-delete-columns`` instead.
- #25471 (Author: Kevin Tang): Fix subfield pushdown arg index for selecting entire struct column
  - Fix subfield pushdown arg index for scalar functions to support selecting whole struct column.

# All Commits
- aa7d196be475316b01922b20a643f1e0a981f8b2 pass TERM signal to application (duhow)
- 9ded1b08ef922bbc2bff01049fae2d7ffe09bbef mount installer package instead of copy (duhow)
- 7365d0c6fe1d34ca033d38121c7b0efdb9bd6395 reorder layers to install base apps first (duhow)
- 855f53f3d239a8ce456b745136dda94b3afe4191 create folder recursive, create data volume (duhow)
- 2645fcd9196d1539d14e03dc91cba06c6b7f1509 cache dnf installer (duhow)
- 8425dab3ce9c306a93da41276acc962b47567e5f chmod executable jar on copy (duhow)
- 4cd16b0f28d07dedb6580a0c29e3784f54f29aa0 [native] Advance velox (Amit Dutta)
- b7289b6a03f9f29e79c2955eb44c1a4b6c3af074 Make rowid optional in DELETE query plan (#25284) (Gary Helmling)
- d8bb991927f49a17034272a8580b68e03f97721b Fix subfield pushdown arg index for selecting entire struct column (#25471) (Kevin Tang)
- decd7fe8200f964ff945dfa13655a19a7e705679 Enable push down subfields from lambda in related test case (wangd)
- 0eb63035f0cd723c91b23c45825baa931e94d970 Add max column properties to equality delete as join optimizer (Timothy Meehan)
- 1b2a4025100e44c663419674e5d099f64c808212 [docs] Add documentation for offset configuration and session properties (#25463) (Steve Burnett)
- b5d956a58164e062e79850df22a80fb3fcf8996e [docs] Add doc for optimizer debugging session properties (#25456) (Steve Burnett)
- 090973f5c220016c465e326a1dc61e8b60861173 [Native] Advance Velox (aditi-pandit)
- efd615c39ff067c5cc44cbf72a749cca9d124524 Extend subfield pushdown to handle map_filter (Feilong Liu)
- f1fc7ccebd0100ae033a36842a67d0c4aac0e20a CI: Skip prestocpp builds for PRs that only modify presto-docs (Jalpreet Singh Nanda (:imjalpreet))
- 523c6b61f857e8125b176bb43e2e7f56c4ec60b7 Fix some issues of prepare release action (#25375) (Li Zhou)
- 35d4a85d3e0eb36fc0a9bc07c21e18e925bbbab0 Use a single instance of PlanCheckerRouterPluginPrestoClient for EXPLAIN calls (Pratik Joseph Dabre)
- 53073bf2e85595f0b88f77f6cd5f068c302e7545 Add config property to enable fallback to Java cluster router when plan checker clusters are unreachable (Pratik Joseph Dabre)
- 4fef5e11dc4e701c8bd832512595dd8ce999d2f4 Add support for handling multiple rows in function server (Joe Abraham)
- 21a37b83bbb09efa11e2a313da8de7153be56de6 Migrate maven publishing service from OSSRH to Central Portal (#25441) (Li Zhou)
- 52a732fef563f425ef99e79ccf029a4fb7fc50f6 Add crossref in admin/properties.rst (Steve Burnett)
- 36849d2c54ecf21f1e6582aa7f44cc7939c1a67f [native] Advance velox (Amit Dutta)
- 8f17c0c414d2aed33df617f03d34d78299a5daa1 [native] Dynamically Linked Library in Presto CPP (Soumya Duriseti)
- 72490a597961e1b35a293d2c65cf73a99f34defe Refactor MetadataDeleteNode to spi Plan (#25430) (Natasha Sehgal)
- 9dafddcc82ca76bb6d11568420ec88040e9fc196 Enable subfield pushdown for map when key is negative (Feilong Liu)
- 42d89fa77e4af448a4da30905057adb2172d8a53 CI: Skip prestocpp builds for PRs that only modify presto-docs (Jalpreet Singh Nanda (:imjalpreet))
- 3edc0adc604ed37f89fbb0221272ce203aa4323c Extend remove map cast rule to cover map_subset function (Feilong Liu)
- 3acc3aefe78174318e166502da3b940482b6bba6 Advance Velox, update Native tests (Natasha Sehgal)
- 4af65e7c14301e12f197a68b235842fb78ac3f18 Add l2_squared java implementation (#25409) (Zhichen Xu)
- 73c3d4ab4c441c42d6c8fd592be3413c5f1b2f85 Add an option to have HBO return output size with individual variable size (Feilong Liu)
- 2f7f08f720361b305f19b54a1b15c247cc85417b Extend max_by/min_by optimization to mix of array/map/scalar type (Feilong Liu)
- a05bc683f68acfceb1b8741f3b04d4c34868ffce Enable subfield pushdown for map_subset function (Feilong Liu)
- 3c1de84207e2d062480a74c714845f39045fd1b5 Move UnnestNode to SPI and add to collector optimizer (Feilong Liu)
- ffe4597a458bc105a8ae5bdc997f51ab6678f4fd Fix Hive Metastore Impersonation in Hive Docs (Jalpreet Singh Nanda (:imjalpreet))
- d7af26531adae67840cd93bf5067047fb37f1112 optimize APPROX_DISTINCT operations on constant conditional values (#25262) (Henry Edwin Dikeman)
- e8eabd7a9996ce8f023c662f8095692a92dfe7d2 [docs] Document delete-related Iceberg metadata columns (Andrew Xie)
- 9040ad48d4631e38b8e67831219b3240f0b26d3f [Iceberg] Support deleted and delete_file_path metadata columns (Andrew Xie)
- 0a504d20e69db9d82b28fe475f623c13ac149765 Support JVM tzdata 2025a (Andrew Xie)
- 33498e46b0c932656c5f48a793d79617032d56af Register SplitListener in PrestoServer (Wei He)
- d2c3214644b5854a58d3f2fb15f1a1b59edb01f6 Add native_max_num_splits_listened_to session property (2/2) (Wei He)
- a231defcc01fc7a769b83b6353b9395e1a6a171c [native] Advance velox (Amit Dutta)
- 93d6e4c1a364cb0f1dae44a5b3c73da6eb2e2f40 Disable CopyOnFirstWriteConfiguration config property by default (Jalpreet Singh Nanda (:imjalpreet))
- b38dcc0e13c1c8739fe6058cf4236bc11912a096 [native] Disable TestPrestoNativeAsyncDataCacheCleanupAPI (Amit Dutta)
- 8d5e52df798f3f261df66cab6c1cc17e4713942f Add --depth 1 to scripts to account for string to array change in github_checkout (mohsaka)
- b839116ef1adeebbd8298a614088e13b6788aa37 Add e2e tests for presto plan checker router plugin tests (Pratik Joseph Dabre)
- fc4ac279b76ac6513f90f1c74f50b70505e45bcb Introduce PlanCheckerPluginHttpRequestSessionContext to remove the cast from Object to HttpServletRequest (Pratik Joseph Dabre)
- f008f35ac602a935d8066498d41cbd6e7b249ca4 update properties-session.rst (Wei He)
- ec350219941488a639e579ea8662f6d66dc11e01 Add Java session property for max split count to listen to (Wei He)
- effee47bd4ad70d795802d705ff0e971abc79d94 [native] Fix calculation of queued drivers threshold. (Sergey Pershin)
- 97cb2586248ee05e59546a7921707e1eaa7bd06e [native] register presto namespace for cudf (Zoltan Arnold Nagy)
- 8f6f16e82d7abd2cf361eeaa0dd73da1f4248d19 Back out "[presto][diff_train] Add write mapping" (Sebastiano Peluso)
- 61a33c89ef350cf6e6954ea364aa72761894c990 Upgrade kafka version to 3.9.1 in response to CVE-2025-27817 (namya28)
- 64f1f5e8ceb2c4f53639ea3751bb73cb5e0ee919 [native] Fix calculation of queued drivers threshold. (Sergey Pershin)
- bb3ad7a5bbf4671b9d9e98b8ec767086e1bc1343 [native] Advance velox (Amit Dutta)
- 4da582ef46d2e539eaa5a0ae52cf55e5e309637a [native] Use both CPU and number of queued drivers in worker overload pushback (Sergey Pershin)
- 36feaa1ac064971c29726d227f1502c2f9562d2c TDigest - Add Quantiles At Values to Documentation (Natasha Sehgal)
- ee3be27350260951745b1ca45c91070e314d5113 [native] Advance velox (Amit Dutta)
- 09f555c42a198a713bbc6796a5e8f7e04162ac50 PartitionAndSerialize Operator: Allocate keyOutputBuffer with pre-determined size (Emily (Xuetong) Sun)
- 825cbc30120bd2d5eedf7d2a2e183471a0cb9cfe [native] Allow non power of two task concurrency for native execution (Andrii Rosa)
- ed3186879289cc483379b56fba0f85a4002c862d [native] Fix prestissimo dependency install (Christian Zentgraf)
- d93972aed2892ad8c7180a9333a035ded684ab99 [native]: Cancel in progress CI runs for the same PR (Deepak Majeti)
- 569d8c18ddb45c739f174972bc6216cb6bcab9e3 [Iceberg]: Disable collection of new stats for native execution (Mahadevuni Naveen Kumar)
- 9eb1964cd2b9c583b8e3b9ea100425972f913c7f Test concurrent map (jay.narale)
- 71123fb7512b7e633111f66e087e6cd52c2c00e8 test (jaystarshot)
- 5b4a3b1bf69ae8f9e682310709a892b7ffba6ce6 Make prometheus metric updation async (jay.narale)
- aaf3d3cb5a1ac03c8096b6a405829ebda37ec46f Fix an issue while accessing Symlink tables (Jalpreet Singh Nanda (:imjalpreet))
- bd18f315b2a3c6af9b795fd00f85d2d552069253 Route user errors from the EXPLAIN call to Java cluster for fallback (Pratik Joseph Dabre)
- 8be07b937937d0467cdf4c7623acc2a185b1f149 Use targetFilesystem for Symlink Table split generation (Jalpreet Singh Nanda (:imjalpreet))
- bbcdfa810c20d14e17c9c267e7ac37b3ac3c9afd Fix MethodTooLargeException for queries with high projection counts (Anant Aneja)
- 9837a07a992040ae8845a62d73c972d37f9e3ac6 Introduce IcebergPartitionField (Ping Liu)
- ba9c38eb9104d8420e9bcb1caa9015c65be24a9f Add output size calculation to BinarySortableSerializer (#25359) (Emily (Xuetong) Sun)
- b6d69f1e52befd080befc8b1e56886b004774a60 [native] Limit macos CI tests to C++ changes (Deepak Majeti)
- e6add57866dc2ccc1110ce709398c1c82b729a2e [native] Do not queue Tasks if the Query is already running (Sergey Pershin)
- 2e0242020c062416884c0bdee45d520ce76b86fc [native]: Enable Velox cuDF (Deepak Majeti)
- 7739b44f477b8960aefa2932aae4d5aaa4009384 Add Avro Configuration Properties to Hive connector docs (martinsander00)
- f19fee9c66cc984b8b2cf09d610c0f212dc55713 Add write mapping (Hazmi)
- 2f6bcb9910018dc3753cd0e3453e2156c53fb88f [native] Fix Task status reporting for not started Tasks (Sergey Pershin)
- 456584feda9cd782e0ef4be373f05ccae91c6f45 added aws-sdk-v1 dependency for redshift jdbc driver (Ajay Kharat)
- 60360ceef2f842da0cc31f0754cf9a03b0dafbf1 [native] changes in ProtocolToThrift files based on IDL change (#25308) (vhsu14)
- a858cbdcaf92270e7b5e16ed4277efe7e9c32e36 [native] Add 'hasStartedTasks' to QueryCtxCacheValue. (Sergey Pershin)
- 477ecd5f215852a2f88b1f1985f8c5002e29102e Bind PlanCheckerRouterPluginScheduler and fix META-INF/services/ file in presto-plan-checker-router-plugin (Pratik Joseph Dabre)
- 4739e83dbee3f4c86aac36c4c91077ee00de0d8e Add native memory pool reclaimer property (#25325) (Chandrashekhar Kumar Singh)
- 5e2870adc4a0d5c231afc15e06ab6cd9814cdb55 Fix confusing word for task state (Shang Ma)
- 00a30bd74c717690e2742fcfb7ecb965d015de97 Add presto-native-sidecar plugin to Provisio plugin (Shakyan Kushwaha)
- c62c4970454ed514ea912220df960832a3341b4e [native]: Add warning when environment variables are used in build (Deepak Majeti)
- 818786cd34d07b1cfe322c3287bc974a9f0c60d0 Add dummy class to deploy presto-native-tests module (#25328) (Li Zhou)
- 8fa7a1726b8682015feb263eb8e866d8183b5c14 [native] Add header proxygen::HTTP_HEADER_HOST to PrestoExchangeSource (Deepak Majeti)
- 3fd0609110c874f49eef266c869b04dd9884b1fa [Iceberg] Fix querying data_sequence_number with equality deletes (Andrew Xie)
- 3fd49931e1f89e1957035158bec0950d934c5b93 Add runtime stats metrics for subcomponent in Optimizer (Chandra Vankayalapati)
- ee7ec12b0bba56042fc42af5161829b911d8095e [native] Advance velox (Amit Dutta)
- c26cb2d3e1de5fba4a9c97cd8b35ec68a73b367c [native] Advance Velox (Christian Zentgraf)
- f137ef245a23906b458470f9d0da72387057b985 Support free unused buffer in output buffer chunk supplier (Chen Yang)
- 3dea808c726cd21e3e9e7b3d368d58c96e4224a8 [native] Add TestAggregations to native-tests (Pramod Satya)
- e544e4c0bc2a9c17ce94a4b8a6d8a09d3ffd1b1f Add QDigest, TDigest to supported native types (Pramod Satya)
- 642b9ea2799acb08c23e3dfea1ffd50029397e21 Parameterize aggregation tests to support DWRF (Pramod Satya)
- 32316a5f71fd7a0944878e832730111c19305139 Remove overriden testcase testCountDistinct (Pramod Satya)
- 95bbacf442ce5e7b84e79f9f966d038feb3de3df Remove path restrictions for cpp tests (Rebecca Schlussel)
- 99d40ea4149c5d76e66258f0c17859f463aafbd0 Disable `AbstractHiveSslTest` (Tim Meehan)
- 786324b5aa8a4dfcd7165034ba8a2ea342d1afb0 Unify and utilize NPROC variable for Linux setup scripts (Christian Zentgraf)
- 8e4c0c88e8e4a0d35071d8fb6c7461250adc23dc Update drift annotation for HostAddress and TimeZoneKey (#25292) (Shang Ma)
- db3db7f0b40c611b0f93b9537882b1ce4176a19c Fix qDigest values_at_quantiles function to throw INVALID_FUNCTION_ARGUMENT on null input (#25291) (XiaoDu)
- a3f2c3eb3f6d32391bc8c23fd3f174bfd1ab48a9 [native] Fix MacOS build errors due to TimeZoneKey and sequenceId type (Deepak Majeti)
- d6705fcec4b4af3f9f3ea35c23d538209c95b057 Revert Move Bootstrap.class to presto-bytecode to avoid duplicate definitions [D75970190] (#25260) (Shelton Cai)
- 4cc1b8687848bc960ccd9c2f4987810ef01d5bd1 Add @unidevel as committer for CI (Timothy Meehan)
- a99fa3259495effd6fd17809e86d66fd0231fb26 Share code between router ui and presto ui (#25223) (Auden Woolfson)
- 539b538d68f43488b18726d036843d3b974e28e1 Revert "Support native non-equal lookup join planning" (Zac Wen)
- d69d55ef80cf38670956826d3a1f89ebeaa6c543 [native] Fix incorrect use of TestNG parameters in native-tests (Pramod Satya)
- b1bddba5666a79422c3d141ffc3a935d293183d4 Fall back to original plan if index join rewrite fails (Zac Wen)
- a118315c3210286fd783d0cce9c35dbfbe3add09 Avoid object creation when call replaceChildren for CteConsumerNode (wangd)
- c6115c325f6d6b6465b24d97cfd8de915e25ca1d [docs] Document config properties required to set up presto-plan-checker-router-plugin (Pratik Joseph Dabre)
- 39da6290fbef2faba06144b68a180ea1a7f5bb78 Add tests for presto-plan-checker-router-plugin and CI job (Pratik Joseph Dabre)
- 5c3560a97f589ee827bcd0e0999a22c69f43ec4f Add a new router plugin : presto-plan-checker-router-plugin (Pratik Joseph Dabre)
- 7587c1508e66a7bdadef6c4fc930a534bf26f223 Fix error classification for array with null elements (Zhiying Liang)
- fdc6e653efa31d9e1890ea80769ff507eba01790 Optimize partition value evaluation in filter pushdown (Feilong Liu)
- 91a8685c231c18bd295a41d120cc4cdaa4229bbb [native] Allow options for wget and tar commands during setup Part:2 (Shakyan Kushwaha)
- 22e4de1f1d199baedd3551a63fe922c57af1ee0a [native] Add remaining from spill header to http shuffle API (Jialiang Tan)
- b865ea7e8f7293015c437b74a8d614ed39b3f525 Fix TestEventListener's multi-threads visibility issue with volatile (wangd)
- df71d0544de9d5c597f5396813079d819db836c5 Support native non-equal lookup join planning (Zac Wen)
- cfbf6f301e39d7c8aeef8a364503e6cc576ca849 Extend native type rewrite for cast, function call, and simple case expression (#25142) (HeidiHan0000)
- 2ba9e2740c0d579f1ef09fe18d77289875d86603 Mixed case support product tests for hive and mysql connectors (NivinCS)
- f6edd43a1abd5e76aa4ea03e5958f68c388749be Add runtime stats for normalizeIdentifier (Reetika Agrawal)
- ea69a73c7efc89e59086aeaca81ba7efb6b3553e Mark deprecate for case-insensitive-name-matching (Reetika Agrawal)
- cb3ba8631634f3f8b944626a050073a7dde531c1 Enable mixed-case support for mysql (Reetika Agrawal)
- 454f12d2382945cf15425752d372137c0d135b13 Mixed case identifier support (Reetika Agrawal)
- ba38759de96f6cc37afb4d3eef0b01c9e7a4b825 [native] Advance velox (Amit Dutta)
- 02eb6fe0361a0be9db682f6efd844b1688cd509b Fix replaceColumn not retaining positionCount of Page (Andrew Xie)
- 6c7de58678b3ec0df8729156d2f9a735d8f01079 Fix native plan checker for CTAS and insert queries (Tim Meehan)
- 6f4a804952c473efe778d14ef8954c43ae3080b0 Enable native plan checker by default (Tim Meehan)
- ae708f0d713fa026b6a7c0fc3fee7d01a6c79547 Allow query runners to load plan checkers (Tim Meehan)
- 39b173af9068ad90c2cbef8006309431d6142acf Remove unused logger (Tim Meehan)
- f3e770a8f9d452109ec8b83cdab41bd9a71e738b Fix ANALYZE when Hive partition has non-canonical value (Denodo Research Labs)
- 1d46dc8a3fcfbb03df3559c71b7c56a792be59a5 Add comment for AddDistinctForSemiJoinBuild optimizer (Feilong Liu)
- 9852c1e9c5d3940211fce3cade2811b5326189d8 Add a session property to disable ReplicateSemiJoinInDelete optimizer (Feilong Liu)
- 369570eed504d3d75560e7a336ffee9d323270f9 Generate ProtocolToThrift files through make and commit (#25162) (vhsu14)
- 3719f8c53c7b1faafe03128835cc21203427355c Add method signature to log (#25252) (Shang Ma)
- d5e76afa9522e4ea7dc397cc57d0486ab433cb28 Add an optimizer to add distinct below build side of semi join (Feilong Liu)
- c84aa3d01aef3a7eb189cea30f38a85063c1c846 Add description for MinMaxByToWindowFunction optimizer (Feilong Liu)
- f139081943952edce7dd68338e65866202b8a20b [native] Enable sidecar in presto-native-tests module (Pratik Joseph Dabre)
- c5839d9396cdca8f7a4ee6c3e22fc5c052016cd6 [Iceberg]Prefix table (loaded from Hive Catalog) with catalog name (wangd)
- a471b4770b83939f905d60cdc5c72bab5e3c1078 update deps (Yihong Wang)
- c708f11a2c463ddec35e577f0319842ed85edf76 fix loading bug (auden-woolfson)
- 8002473599d728a52872fb6bd07aed89cf7c1acc Undo unrelated change (auden-woolfson)
- edf51c4d218ba9e6b1f37a09d8608b8b96cf7d07 Version change (auden-woolfson)
- 28e739904d471b6464da8b17b0df7490ea1f1264 Add version to comment (auden-woolfson)
- ffc2be330315a552646aad05c51c7a1b865c43e4 Cherry pick router whitesource fixes (Auden Woolfson)
- 58e84892fcea8a40a530aebcef36781dc665fd4b Use RouterRequestInfo in router schedulers to get the URL destination (Pratik Joseph Dabre)
- f4f1934b5f248d7931146d8d312fc7ddccca8e1d Add function metadata ability to push down struct argument in optimizer (#25175) (Kevin Tang)
- a7681b66b6fdb46c5995b19dfeb53f75230d91e2 Move Bootstrap.class to presto-bytecode to avoid duplicate definitions (wangd)
- c08c6ef45ac9f9cbf2efc4f8d6e8594183d6de99 Fix vulnerability issue in commons-beanutils to address CVE-2025-48734 (Shahim Sharafudeen)
- 0729c1d6c89740b85db14fa1a64b3178f3076342 Add optimizer to convert min_by/max_by to row number function (Feilong Liu)
- 8a04ee308b471a017a29827af7cc0a786185b52a Add support for mTLS authentication in Arrow Flight client (Elbin Pallimalil)
- d5b77702b09a81a5f47fe8c66c0aaf454cb283e6 [prestissimo] Add async pushback for jemalloc purge (Jialiang Tan)
- a504c7c5dd4c324cd17fd5b19b64dba79daaa727 [native] Improve semi join parallelism (Andrii Rosa)
- 1bc7da4b2e28452496af309484ab7d1949db1b9c Extend filtered aggregation optimizer to support only masked partial aggregation cases (Feilong Liu)
- a12b523c145449d5317b77f747782abfda264e9b [native] Use builder pattern for native queryRunner (Pramod Satya)
- f0fffd36092b407424a7d413c5b2f87e12a8449a [native] Fix constant in lookup condition parsing (Zac Wen)
- a35b9fc18cd87fdcfb7373f0473fa41f87eb684e Update presto-cli troubleshooting docs (pratyakshsharma)
- b53d94dfe185f2a7f92c595640a7f2271f2aea35 Add session to getFlightDescriptorForSchema and getFlightDescriptorForTableScan (Thanzeel Hassan)
- 61d1700567c0efa75701d224d50d2fa51413bbda Fix ordering of arguments in arrow flight module (Thanzeel Hassan)
- e73f450c9fd3940434ff6225b03f0582cbdc6ff2 [native] Move exception map to cpp file to prevent from SIOF (Amit Dutta)
- 0eb6adb0de135235289dc6929ca96e7b72247593 Fix time caculation error for method execution  (#25231) (Shang Ma)
- c83b2221f1d623ca217fc523b761412560d990b7 [native] Allow accessing error code map to register custom exceptions. (Amit Dutta)
- e95d9fba040539f070bf351bf1d457e2105f6e76 Fix flaky test of table registration in Nessie (wangd)
- 783c58e6b51fc2b39e316da56d6810aa474ad9eb [Iceberg]Support rename view on Rest catalog and Nessie catalog (wangd)
- e93a5f83f14ef4885aa2814d02edfd54019fa9fe convert MemoryManagerOptions to MemoryManager::Options (#25229) (Ke Wang)
- fda51140321fca27f8054786c3ceedd555700cb5 [doc] Remove duplicate 'async-cache-persistence-interval' property (lingbin)
- d9f71c41dca2e7454eb8d2d5bce1b0dd2c1a24bf Fix procedure remove_orphan_files with DELETES (Denodo Research Labs)
- 831323a2bea25ef5c22cb5d74920b65c1d1805a8 [sidecar] Prevent coordinator crashing in non-sidecar enabled clusters by making sidecar plugin functionalities config driven (Pratik Joseph Dabre)
- 1e533c81231bcace510cf38bbf0f8d0fb2f21c1d [native] Fix dependency build dockerfiles (Deepak Majeti)
- d3f7172b275ce7310fc126269c67fb55bdd5a23c Fail query runner when nodes do not come up (Tim Meehan)
- f811f7e4077e551f2e56959647e13b7dd6f4fa97 Add session property for passing query client timeout value (#25210) (Arjun Gupta)
- 3ef776929755ecac66e31760284a93fcc154ae93 [native] Advance Velox (Deepak Majeti)
- 73c2945c82c8d41d649e83aa802d2a7b0aff4104 Fix the khyperloglog_agg() example (mima0000)
- a083fd530827dd2af3347ebe800f0549b0570272 Add some working examples for functions in aggregate.rst (mima0000)
- 6a455ac192c38f24b61d4c97f51ad36886ddec36 Add support for json type in MongoDB (Mariam Almesfer)
- dbe3d365c07bc20b5006b420f124f4317eb7fe2d Add config option to skip system schemas in JDBC connectors (Hazmi)