### PR TITLE
Add release notes for 0.295

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    Release-0.295 [2025-09-24] <release/release-0.295>
     Release-0.294 [2025-07-28] <release/release-0.294>
     Release-0.293 [2025-05-29] <release/release-0.293>
     Release-0.292 [2025-03-28] <release/release-0.292>

--- a/presto-docs/src/main/sphinx/release/release-0.295.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.295.rst
@@ -1,0 +1,147 @@
+=============
+Release 0.295
+=============
+
+**Highlights**
+==============
+
+**Details**
+===========
+
+General Changes
+_______________
+* Fix `localtime` and `current_time` in legacy timestamp semantics. `#25985 <https://github.com/prestodb/presto/pull/25985>`_
+* Fix a bug where map(varchar, json) does not canonicalize values. :doc:`/functions/map`. `#24232 <https://github.com/prestodb/presto/pull/24232>`_
+* Fix add exchange and add local exchange optimizers to simplify query plans using the unique $row_id. `#25882 <https://github.com/prestodb/presto/pull/25882>`_
+* Fix failure when preparing statements or creating views that contain a quoted reserved word as a table name. `#25528 <https://github.com/prestodb/presto/pull/25528>`_
+* Fix iceberg connector rename column failed if the column is used as source column of non-identity transform. `#25697 <https://github.com/prestodb/presto/pull/25697>`_
+* Improve Iceberg's `apply_changelog` function by migrating it from the global namespace to the connector-specific namespace. The function is now available as `iceberg.system.apply_changelog()` instead of `apply_changelog()`. `#25871 <https://github.com/prestodb/presto/pull/25871>`_
+* Improve ``DELETE`` on columns with special characters in their names. `#25737 <https://github.com/prestodb/presto/pull/25737>`_
+* Improve efficiency by supporting thrift codec for connector-specific data. `#25595 <https://github.com/prestodb/presto/pull/25595>`_
+* Improve efficiency of coordinator by supporting thrift codec for connector-specific data. `#25242 <https://github.com/prestodb/presto/pull/25242>`_
+* Improve test framework to return ``startTransactionId`` and ``clearTransactionId`` flag to client. `#25053 <https://github.com/prestodb/presto/pull/25053>`_
+* Improve the property mechanism to enable a property to accept and process property values of multiple types. `#25862 <https://github.com/prestodb/presto/pull/25862>`_
+* Add  Scale and Precision column to get the respective scale of the decimal value and precision of numerical values.Additionally  Length  column is introduced to get the length of Char and Varchar fields. `#25351 <https://github.com/prestodb/presto/pull/25351>`_
+* Add Cache-Control header with max-age to statement API responses. `#25433 <https://github.com/prestodb/presto/pull/25433>`_
+* Add `X-Presto-Retry-Query` header to identify queries that are being retried on a backup cluster. `#25625 <https://github.com/prestodb/presto/pull/25625>`_
+* Add `presto-sql-helpers` directory for inlined SQL invoked function plugins with plugin loading rules. `#26025 <https://github.com/prestodb/presto/pull/26025>`_
+* Add a new built-in plugin function namespace manager interface: ``BuiltInPluginFunctionNamespaceManager``. `#25597 <https://github.com/prestodb/presto/pull/25597>`_
+* Add a new plugin : `presto-native-sql-invoked-functions-plugin` that contains all inlined SQL functions except those with overridden native implementations. `#25870 <https://github.com/prestodb/presto/pull/25870>`_
+* Add a session property to change the maximum serializable object size at the coordinator. `#25616 <https://github.com/prestodb/presto/pull/25616>`_
+* Add all inlined sql invoked functions into a new plugin `presto-sql-invoked-functions-plugin`. The following functions were moved: - replace_first - trail - key_sampling_percent - no_values_match - no_keys_match - any_values_match - any_keys_match - all_keys_match - map_remove_null_values - map_top_n_values - map_top_n_keys - map_top_n - map_key_exists - map_keys_by_top_n_values - map_normalize - array_top_n - remove_nulls - array_sort_desc - array_min_by - array_max_by - array_least_frequent - array_has_duplicates - array_duplicates - array_frequency - array_split_into_chunks - array_average - array_intersect. `#25818 <https://github.com/prestodb/presto/pull/25818>`_
+* Add array_sort(array, function) support for key-based sorting. `#25851 <https://github.com/prestodb/presto/pull/25851>`_
+* Add array_sort_desc(array, function) support for key-based sorting. `#25851 <https://github.com/prestodb/presto/pull/25851>`_
+* Add property ```native_index_lookup_join_max_prefetch_batches``` which controls the max number of input batches to prefetch to do index lookup ahead. If it is zero, then process one input batch at a time. `#25886 <https://github.com/prestodb/presto/pull/25886>`_
+* Add property ```native_index_lookup_join_split_output```. If this is true, then the index join operator might split output for each input batch based on the output batch size control. Otherwise, it tries to produce a single output for each input batch. `#25886 <https://github.com/prestodb/presto/pull/25886>`_
+* Add property ```native_unnest_split_output```. If this is true, then the unnest operator might split output for each input batch based on the output batch size control. Otherwise, it produces a single output for each input batch. `#25886 <https://github.com/prestodb/presto/pull/25886>`_
+* Add sqlText to SessionContext to be used by system access control APIs. `#26054 <https://github.com/prestodb/presto/pull/26054>`_
+* Add support for BuiltInFunctionKind enum parameter in BuiltInFunctionHandle's JSON constructor creator. `#25821 <https://github.com/prestodb/presto/pull/25821>`_
+* Add support for configuring http2 server on worker for communication between coordinator and workers. This can be enabled by setting the property ``http-server.http2.enabled`` to  ``true``. `#25708 <https://github.com/prestodb/presto/pull/25708>`_
+* Add support for cross-cluster query retry. Failed queries can now be automatically retried on a backup cluster by providing retry URL and expiration time as query parameters. `#25625 <https://github.com/prestodb/presto/pull/25625>`_
+* Add support for using a netty client to do HTTP communication between coordinator and worker. This new http client can be enabled on the coordinator by setting the config ``reactor.netty-http-client-enabled`` to ``true``. `#25573 <https://github.com/prestodb/presto/pull/25573>`_
+* Add test methods ``assertStartTransaction`` and ``assertEndTransaction`` to support non-autocommit transaction testing scenarios better. `#25053 <https://github.com/prestodb/presto/pull/25053>`_
+* Added SpatialJoinNode to presto_protocol and presto_protocol_core. `#25823 <https://github.com/prestodb/presto/pull/25823>`_
+* Added a new db-based session property manager. :doc:`/admin/session-property-managers`. `#24995 <https://github.com/prestodb/presto/pull/24995>`_
+* Added support to use the MariaDb Java client with a MySQL based function server. `#25698 <https://github.com/prestodb/presto/pull/25698>`_
+* Update Provisio packaging to split plugin packaging into plugins and native-plugins directory. `#25984 <https://github.com/prestodb/presto/pull/25984>`_
+* Update Provisio plugin to package memory connector plugin under native-plugin/. `#26044 <https://github.com/prestodb/presto/pull/26044>`_
+* Update TableWriterOperator to set the Connector Session Runtime Stats to the Operator Context Runtime Stats. Previously, this was set to the Session object's Runtime Stats. This change ensures any metrics added to the Connector Session's Runtime Stats while executing a TableWriterOperator will be available as Operator Stats. `#25846 <https://github.com/prestodb/presto/pull/25846>`_
+* Update to preserve table name quoting in the output of ``SHOW CREATE VIEW``. `#25528 <https://github.com/prestodb/presto/pull/25528>`_
+* Upgrade Jetty webserver to 12. `#24866 <https://github.com/prestodb/presto/pull/24866>`_
+* Upgrade Presto to require Java 17. The Presto client and Presto-on-Spark remain Java 8-compatible. Presto now requires a Java 17 VM to run both coordinator and workers. `#24866 <https://github.com/prestodb/presto/pull/24866>`_
+* Upgrade airlift to 0.221. `#24866 <https://github.com/prestodb/presto/pull/24866>`_
+* Upgrade guice to 6.0. `#24866 <https://github.com/prestodb/presto/pull/24866>`_
+
+Prestissimo (native Execution) Changes
+______________________________________
+* Add parameterized varchar type in the list of supported types in NativeTypeManager. `#26003 <https://github.com/prestodb/presto/pull/26003>`_
+* Update coordinator behaviour to validate sidecar function signatures against plugin loaded function signatures at startup. `#25919 <https://github.com/prestodb/presto/pull/25919>`_
+* Use Presto built-in functions for constant folding when native execution is enabled with sidecar. `#25135 <https://github.com/prestodb/presto/pull/25135>`_
+
+Security Changes
+________________
+* Fix CSP by adding `form-action 'self'` and setting `img-src 'self'` in response to `CWE-693 <https://cwe.mitre.org/data/definitions/693.html>`_. :pr:`25910`. `#25910 <https://github.com/prestodb/presto/pull/25910>`_
+* Add AuthenticatorNotApplicableException to prevent irrelevant authenticator errors from being returned to clients. `#25606 <https://github.com/prestodb/presto/pull/25606>`_
+* Upgrade MongoDB Java server  to 1.47.0 in response to the use of an outdated version. `#25761 <https://github.com/prestodb/presto/pull/25761>`_
+* Upgrade Netty to version 4.1.126.Final to address 'CVE-2025-58056  <https://github.com/advisories/GHSA-fghv-69vj-qj49>' and 'CVE-2025-58057  <https://github.com/advisories/GHSA-3p8m-j85q-pgmj>' _. `#26006 <https://github.com/prestodb/presto/pull/26006>`_
+* Upgrade commons-lang3 to 3.18.0 to address `CVE-2025-48924 <https://github.com/advisories/GHSA-j288-q9x7-2f5v>`. `#25751 <https://github.com/prestodb/presto/pull/25751>`_
+* Upgrade jaxb-runtime to v4.0.5 in response to CVE-2020-15250. `#26024 <https://github.com/prestodb/presto/pull/26024>`_
+* Upgrade jdbi3-core:3.4.0 to 3.49.0 and jdbi3-sqlobject:3.4.0 to 3.49.0 in response to the use of an outdated version. `#26021 <https://github.com/prestodb/presto/pull/26021>`_
+* Upgrade netty dependency to address 'CVE-2025-55163  <https://github.com/advisories/GHSA-prj3-ccx8-p6x4>'. `#25806 <https://github.com/prestodb/presto/pull/25806>`_
+* Upgrade objenesis version  to 3.4  in response to the use of an outdated version. `#25918 <https://github.com/prestodb/presto/pull/25918>`_
+* Upgrade org.antlr version to 4.13.2  in response to the use of an outdated version. `#25990 <https://github.com/prestodb/presto/pull/25990>`_
+* Upgrade org.apache.yetus:audience-annotations version to 0.15.1 in response to the use of an outdated version. `#26019 <https://github.com/prestodb/presto/pull/26019>`_
+* Upgrade org.fusesource.jansi:jansi version to 2.4.2  in response to the use of an outdated version. `#25991 <https://github.com/prestodb/presto/pull/25991>`_
+* Upgrade org.reflections to 0.10.2 in response to the use of an outdated version. `#25931 <https://github.com/prestodb/presto/pull/25931>`_
+* Upgrade org.scala-lang:scala-library version to 2.13.16  in response to the use of an outdated version. `#26007 <https://github.com/prestodb/presto/pull/26007>`_
+* Upgrade reactor-netty-http dependency to address 'CVE-2025-22227  <https://github.com/advisories/GHSA-4q2v-9p7v-3v22>'. `#25739 <https://github.com/prestodb/presto/pull/25739>`_
+
+Base JDBC Connector Changes
+___________________________
+* Add decimal type support to query builder. `#25699 <https://github.com/prestodb/presto/pull/25699>`_
+
+Bigquery Connector Changes
+__________________________
+* Fixed query failures on SELECT operations by aligning BigQuery v1beta1 with protobuf-java 3.25.8, preventing runtime incompatibility with protobuf 4.x. `#25805 <https://github.com/prestodb/presto/pull/25805>`_
+* Add support for case-sensitive identifiers in BigQuery. Set the configuration property in the catalog file as follows to enable: ``case-sensitive-name-matching=true``. `#25764 <https://github.com/prestodb/presto/pull/25764>`_
+
+Cassandra Connector Changes
+___________________________
+* Add support to read TUPLE type as a Presto VARCHAR. `#25516 <https://github.com/prestodb/presto/pull/25516>`_
+
+Clickhouse Connector Changes
+____________________________
+* Add support for case-sensitive identifiers in Clickhouse. It can be enabled by setting ``case-sensitive-name-matching=true`` configuration in the catalog configuration. `#25863 <https://github.com/prestodb/presto/pull/25863>`_
+
+Delta Lake Connector Changes
+____________________________
+* Upgrade to Hadoop 3.4.1. `#24799 <https://github.com/prestodb/presto/pull/24799>`_
+
+Hive Connector Changes
+______________________
+* Fix Hive connector to ignore unsupported table formats when querying ``system.jdbc.columns`` to prevent errors. `#25779 <https://github.com/prestodb/presto/pull/25779>`_
+* Add session property ``hive.orc_use_column_names`` to toggle the accessing of columns based on the names recorded in the ORC file rather than their ordinal position in the file. `#25285 <https://github.com/prestodb/presto/pull/25285>`_
+* Upgrade to Hadoop 3.4.1. `#24799 <https://github.com/prestodb/presto/pull/24799>`_
+
+Hudi Connector Changes
+______________________
+* Upgrade to Hadoop 3.4.1. `#24799 <https://github.com/prestodb/presto/pull/24799>`_
+
+Iceberg Connector Changes
+_________________________
+* Fix NPE error in getViews when a schema is not provided. `#25695 <https://github.com/prestodb/presto/pull/25695>`_
+* Fix implementation of commit to do one operation as opposed to two. `#25615 <https://github.com/prestodb/presto/pull/25615>`_
+* Improve `ApplyChangelogFunction` by moving it to connector-level functions following the pattern introduced in PR #25594. `#25871 <https://github.com/prestodb/presto/pull/25871>`_
+* Add Iceberg bucket scalar function. `#25951 <https://github.com/prestodb/presto/pull/25951>`_
+* Add ``iceberg.engine.hive.lock-enabled`` configuration to disable Hive locks. `#25615 <https://github.com/prestodb/presto/pull/25615>`_
+* Add supporting for specifying multiple transforms when adding a column. `#25862 <https://github.com/prestodb/presto/pull/25862>`_
+* Upgrade Iceberg version from 1.5.0 to 1.6.1. `#25768 <https://github.com/prestodb/presto/pull/25768>`_
+* Upgrade Iceberg version to 1.8.1. `#25999 <https://github.com/prestodb/presto/pull/25999>`_
+* Upgrade Nessie to version 0.95.0. `#25593 <https://github.com/prestodb/presto/pull/25593>`_
+* Upgrade to Hadoop 3.4.1. `#24799 <https://github.com/prestodb/presto/pull/24799>`_
+
+Mongodb Connector Changes
+_________________________
+* Add support for case-sensitive identifiers in MongoDB. It can be enabled by setting ``case-sensitive-name-matching=true`` configuration in the catalog configuration. `#25853 <https://github.com/prestodb/presto/pull/25853>`_
+* Upgrade mongodb java driver to 3.12.14. `#25436 <https://github.com/prestodb/presto/pull/25436>`_
+
+Postgres Connector Changes
+__________________________
+* Add support for `GEOMETRY <https://prestodb.io/docs/current/language/types.html#geospatial>`_ type in the Postgres connector. `#25240 <https://github.com/prestodb/presto/pull/25240>`_
+
+Redis Connector Changes
+_______________________
+* Add changes to enable TLS support. `#25373 <https://github.com/prestodb/presto/pull/25373>`_
+
+SPI Changes
+___________
+* Add a new  ``getSqlInvokedFunctions`` SPI  in Presto, which only supports SQL invoked functions. `#25597 <https://github.com/prestodb/presto/pull/25597>`_
+
+Documentation Changes
+_____________________
+* Improve the doc page explaining how to deploy Presto with Homebrew. `#25924 <https://github.com/prestodb/presto/pull/25924>`_
+
+**Credits**
+===========
+
+Abhash Jain, Amritanshu Darbari, Anant Aneja, Andrew Xie, Arjun Gupta, Artem Selishchev, Bryan Cutler, Christian Zentgraf, Christian Zentgraf, Dilli-Babu-Godari, Elbin Pallimalil, Facebook Community Bot, Feilong Liu, Gary Helmling, Ge Gao, Hazmi, HeidiHan0000, Jalpreet Singh Nanda (:imjalpreet), James Gill, Jay Narale, Jialiang Tan, Joe Abraham, Joe O'Hallaron, Karthikeyan Natarajan, Ke Wang, Ke Wang, Kevin Tang, Kewen Wang, Li Zhou, Mahadevuni Naveen Kumar, Maria Basmanova, Mariam Almesfer, Matt Karrmann, Natasha Sehgal, Naveen Nitturu, Nidhin Varghese, Nikhil Collooru, Nishitha-Bhaskaran, PRASHANT GOLASH, Ping Liu, Pradeep Vaka, Pramod Satya, Prashant Sharma, Pratik Joseph Dabre, Raaghav Ravishankar, Rebecca Schlussel, Rebecca Whitworth, Reetika Agrawal, Richard Barnes, Sayari Mukherjee, Sergey Pershin, Shahim Sharafudeen, Shang Ma, Shijin, Shrinidhi Joshi, Steve Burnett, Sumi Mathew, Timothy Meehan, Valery Mironov, Vamsi Karnika, Vivian Hsu, Wei He, Xiaoxuan Meng, Xin Zhang, Yihong Wang, Ying, Zac Blanco, Zac Wen, abhinavmuk04, aditi-pandit, adkharat, aspegren_david, auden-woolfson, beinan, dnskr, ericyuliu, haneel-kumar, j-sund, juwentus1234, mehradpk, mohsaka, pratik.pugalia@gmail.com, pratyakshsharma, singcha, wangd, yangbin09


### PR DESCRIPTION
# Missing Release Notes
## Arjun Gupta
- [ ] https://github.com/prestodb/presto/pull/25589 Support max queued_time limit (Merged by: Arjun Gupta)

## Artem Selishchev
- [ ] https://github.com/prestodb/presto/pull/25750 feat: Add session property for debugMemoryPoolWarnThresholdBytes (Merged by: Artem Selishchev)

## Christian Zentgraf
- [ ] https://github.com/prestodb/presto/pull/26017 [native] Advance velox (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/25978 [native] Advance velox (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/25933 [native] Advance velox (Merged by: Aditi Pandit)

## Ge Gao
- [ ] https://github.com/prestodb/presto/pull/25843 [Native] Parse CharN in protocol to Varchar type (Merged by: Ge Gao)

## Jialiang Tan
- [ ] https://github.com/prestodb/presto/pull/25758 [native] Remove BaseVeloxQueryConfig (Merged by: tanjialiang)

## Nidhin Varghese
- [ ] https://github.com/prestodb/presto/pull/25913 Enhance lineage capture to include column-level details (Merged by: Jalpreet Singh Nanda)

## PRASHANT GOLASH
- [ ] https://github.com/prestodb/presto/pull/25689 [Coordinator throttling] Scheduling Policies for Admission Control based on worker load  (Merged by: PRASHANT GOLASH)
- [ ] https://github.com/prestodb/presto/pull/25687 [Coordinator throttling] Endpoint on Java worker reporting nodestats (Merged by: PRASHANT GOLASH)

## Richard Barnes
- [ ] https://github.com/prestodb/presto/pull/25732 [native] Remove out-of-line definition of constexpr in nlohmann json. (Merged by: Amit Dutta)

## Timothy Meehan
- [ ] 0325368a21b4f6b9c6220575ac1a4b90a3eb71a2 Add a check for CVEs present in new transitive dependencies

## Xiaoxuan Meng
- [ ] https://github.com/prestodb/presto/pull/26031 [sapphire-velox]fix: Fix to handle multiple TaskSource have the same source node (Merged by: Xiaoxuan)

## haneel-kumar
- [ ] https://github.com/prestodb/presto/pull/25388 [native] Add Mutual TLS support to Arrow Flight connector (Merged by: Timothy Meehan)

## juwentus1234
- [ ] https://github.com/prestodb/presto/pull/25684 Add kQueryTraceNodeId in presto session config (Merged by: tanjialiang)

## yangbin09
- [ ] https://github.com/prestodb/presto/pull/25809 Fix Query ID tooltip position in Web UI (Merged by: Timothy Meehan)

# Extracted Release Notes
- #24232 (Author: Hazmi): Resolve map(varchar, json) canonicalization bug
  - Fix a bug where map(varchar, json) does not canonicalize values. :doc:`/functions/map`.
- #24799 (Author: Nishitha-Bhaskaran): Upgrade to Hadoop 3.4.1
  - Upgrade to Hadoop 3.4.1.
  - Upgrade to Hadoop 3.4.1.
  - Upgrade to Hadoop 3.4.1.
  - Upgrade to Hadoop 3.4.1.
- #24866 (Author: Zac Blanco): Java 17 and Jetty 12 upgrade
  - Upgrade Presto to require Java 17. The Presto client and Presto-on-Spark remain Java 8-compatible. Presto now requires a Java 17 VM to run both coordinator and workers.
  - Upgrade airlift to 0.221.
  - Upgrade Jetty webserver to 12.
  - Upgrade guice to 6.0.
- #24995 (Author: Hazmi): Add a DB based session property manager
  - Added a new db-based session property manager. :doc:`/admin/session-property-managers`.
- #25053 (Author: wangd): Enhance the test framework to support non-autocommit transaction testing scenarios better
  - Improve test framework to return ``startTransactionId`` and ``clearTransactionId`` flag to client.
  - Add test methods ``assertStartTransaction`` and ``assertEndTransaction`` to support non-autocommit transaction testing scenarios better.
- #25135 (Author: Timothy Meehan): Always evaluate built-in functions using the presto.default namespace
  - Use Presto built-in functions for constant folding when native execution is enabled with sidecar.
- #25240 (Author: Mariam Almesfer): Add read support for geometry and geography data types in postgres connector
  - Add support for `GEOMETRY <https://prestodb.io/docs/current/language/types.html#geospatial>`_ type in the Postgres connector.
- #25242 (Author: Shang Ma): Add support to provide thrift codec for connector specific fields
  - Improve efficiency of coordinator by supporting thrift codec for connector-specific data.
- #25285 (Author: aspegren_david): 24134 add session property orc use column names
  - Add session property ``hive.orc_use_column_names`` to toggle the accessing of columns based on the names recorded in the ORC file rather than their ordinal position in the file.
- #25351 (Author: Sumi Mathew): Enhance ShowColumns
  - Add  Scale and Precision column to get the respective scale of the decimal value and precision of numerical values.Additionally  Length  column is introduced to get the length of Char and Varchar fields.
- #25373 (Author: Nishitha-Bhaskaran): Support for TLS in Redis Connector 
  - Add changes to enable TLS support.
- #25433 (Author: Andrew Xie): Add Cache-Control header to statement endpoints
  - Add Cache-Control header with max-age to statement API responses.
- #25436 (Author: mehradpk): Upgrade mongodb java driver from 3.6.0 to 3.12.14
  - Upgrade mongodb java driver to 3.12.14.
- #25516 (Author: Bryan Cutler): Add support for tuple type in the Cassandra connector
  - Add support to read TUPLE type as a Presto VARCHAR.
- #25528 (Author: Reetika Agrawal): Preserve quotedness in QualifiedName
  - Update to preserve table name quoting in the output of ``SHOW CREATE VIEW``.
  - Fix failure when preparing statements or creating views that contain a quoted reserved word as a table name.
- #25573 (Author: Nikhil Collooru): Add support for ReactorNettyHttpClient
  - Add support for using a netty client to do HTTP communication between coordinator and worker. This new http client can be enabled on the coordinator by setting the config ``reactor.netty-http-client-enabled`` to ``true``.
- #25593 (Author: Mariam Almesfer): Upgrade Nessie to version 0.95.0.
  - Upgrade Nessie to version 0.95.0.
- #25595 (Author: Vivian Hsu): [native] Add thrift codec for remote split and support for ExecutionWriterTargetUnion
  - Improve efficiency by supporting thrift codec for connector-specific data.
- #25597 (Author: Pratik Joseph Dabre): Introduce `getSqlInvokedFunctions` SPI and `BuiltInPluginFunctionNamespaceManager` for registering sql invoked functions
  - Add a new  ``getSqlInvokedFunctions`` SPI  in Presto, which only supports SQL invoked functions.
  - Add a new built-in plugin function namespace manager interface: ``BuiltInPluginFunctionNamespaceManager``.
- #25606 (Author: Jalpreet Singh Nanda (:imjalpreet)): Add `AuthenticatorNotApplicableException` in presto-spi
  - Add AuthenticatorNotApplicableException to prevent irrelevant authenticator errors from being returned to clients.
- #25615 (Author: Hazmi): Fix iceberg commit atomicity & add `iceberg.engine.hive.lock-enabled` configuration
  - Fix implementation of commit to do one operation as opposed to two.
  - Add ``iceberg.engine.hive.lock-enabled`` configuration to disable Hive locks.
- #25616 (Author: Raaghav Ravishankar): Add max_serializable_object_size system property
  - Add a session property to change the maximum serializable object size at the coordinator.
- #25625 (Author: Timothy Meehan): Add support for retrying on a different cluster
  - Add support for cross-cluster query retry. Failed queries can now be automatically retried on a backup cluster by providing retry URL and expiration time as query parameters.
  - Add `X-Presto-Retry-Query` header to identify queries that are being retried on a backup cluster.
- #25695 (Author: Bryan Cutler): Fix NPE in IcebergHiveMetadata.getViews when the provided schema is null
  - Fix NPE error in getViews when a schema is not provided.
- #25697 (Author: Ping Liu): fix: rename column failed if the column is used as source column of non-identity transform
  - Fix iceberg connector rename column failed if the column is used as source column of non-identity transform.
- #25698 (Author: Anant Aneja): Add support for the MariaDb driver to the function namespace manager
  - Added support to use the MariaDb Java client with a MySQL based function server.
- #25699 (Author: Hazmi): Add back missing WriteMappings for Decimal & Time type
  - Add decimal type support to query builder.
- #25708 (Author: Nikhil Collooru): Make http2 communication configurable
  - Add support for configuring http2 server on worker for communication between coordinator and workers. This can be enabled by setting the property ``http-server.http2.enabled`` to  ``true``.
- #25737 (Author: Naveen Nitturu): Improve DELETE Statement on columns with special characters in their names
  - Improve ``DELETE`` on columns with special characters in their names.
- #25739 (Author: Shahim Sharafudeen): Upgrade reactor-netty-http to 1.2.8 to address CVE-2025-22227
  - Upgrade reactor-netty-http dependency to address 'CVE-2025-22227  <https://github.com/advisories/GHSA-4q2v-9p7v-3v22>'.
- #25751 (Author: Shahim Sharafudeen): Use same commons-lang3 version in product-tests pom file
  - Upgrade commons-lang3 to 3.18.0 to address `CVE-2025-48924 <https://github.com/advisories/GHSA-j288-q9x7-2f5v>`.
- #25761 (Author: Sumi Mathew): Upgrade mongo sever version
  - Upgrade MongoDB Java server  to 1.47.0 in response to the use of an outdated version.
- #25764 (Author: adkharat): Feature Enhancement: Case-Sensitive Support For Bigquery
  - Add support for case-sensitive identifiers in BigQuery. Set the configuration property in the catalog file as follows to enable: ``case-sensitive-name-matching=true``.
- #25768 (Author: wangd): Upgrade Iceberg version to 1.6.1
  - Upgrade Iceberg version from 1.5.0 to 1.6.1.
- #25779 (Author: Jalpreet Singh Nanda (:imjalpreet)): Ignore unknown table formats when querying system.jdbc.columns table
  - Fix Hive connector to ignore unsupported table formats when querying ``system.jdbc.columns`` to prevent errors.
- #25805 (Author: adkharat): Fix for bigquery select not working
  - Fixed query failures on SELECT operations by aligning BigQuery v1beta1 with protobuf-java 3.25.8, preventing runtime incompatibility with protobuf 4.x.
- #25806 (Author: Shahim Sharafudeen): Upgrade netty to 4.1.124.Final to address CVE-2025-55163
  - Upgrade netty dependency to address 'CVE-2025-55163  <https://github.com/advisories/GHSA-prj3-ccx8-p6x4>'.
- #25818 (Author: Pratik Joseph Dabre): Extract all inlined sql invoked functions into a new plugin `presto-sql-invoked-functions-plugin`
  - Add all inlined sql invoked functions into a new plugin `presto-sql-invoked-functions-plugin`. The following functions were moved: - replace_first - trail - key_sampling_percent - no_values_match - no_keys_match - any_values_match - any_keys_match - all_keys_match - map_remove_null_values - map_top_n_values - map_top_n_keys - map_top_n - map_key_exists - map_keys_by_top_n_values - map_normalize - array_top_n - remove_nulls - array_sort_desc - array_min_by - array_max_by - array_least_frequent - array_has_duplicates - array_duplicates - array_frequency - array_split_into_chunks - array_average - array_intersect.
- #25821 (Author: Pratik Joseph Dabre): Support BuiltInFunctionKind enum parameter in BuiltInFunctionHandle's JSON constructor creator
  - Add support for BuiltInFunctionKind enum parameter in BuiltInFunctionHandle's JSON constructor creator.
- #25823 (Author: James Gill): [native] Add SpatialJoinNode to presto_cpp protocol
  - Added SpatialJoinNode to presto_protocol and presto_protocol_core.
- #25846 (Author: Matt Karrmann): feat: Support tracking Page Sink Runtime Stats in TableWriterOperator
  - Update TableWriterOperator to set the Connector Session Runtime Stats to the Operator Context Runtime Stats. Previously, this was set to the Session object's Runtime Stats. This change ensures any metrics added to the Connector Session's Runtime Stats while executing a TableWriterOperator will be available as Operator Stats.
- #25851 (Author: Dilli-Babu-Godari): Add array_sort(array, function) support for key-based sorting
  - Add array_sort(array, function) support for key-based sorting.
  - Add array_sort_desc(array, function) support for key-based sorting.
- #25853 (Author: Reetika Agrawal): Enable case sensitivity support in the MongoDB connector
  - Add support for case-sensitive identifiers in MongoDB. It can be enabled by setting ``case-sensitive-name-matching=true`` configuration in the catalog configuration.
- #25862 (Author: wangd): [Iceberg]Support specifying multiple transforms when adding a column
  - Improve the property mechanism to enable a property to accept and process property values of multiple types.
  - Add supporting for specifying multiple transforms when adding a column.
- #25863 (Author: Nishitha-Bhaskaran): Enable case-sensitive support for clickhouse connector
  - Add support for case-sensitive identifiers in Clickhouse. It can be enabled by setting ``case-sensitive-name-matching=true`` configuration in the catalog configuration.
- #25870 (Author: Pratik Joseph Dabre): [native] Introduce ``presto-native-sql-invoked-functions-plugin`` for sidecar enabled clusters
  - Add a new plugin : `presto-native-sql-invoked-functions-plugin` that contains all inlined SQL functions except those with overridden native implementations.
- #25871 (Author: Amritanshu Darbari): [Iceberg] Migrate ApplyChangeLog to connector function
  - Improve Iceberg's `apply_changelog` function by migrating it from the global namespace to the connector-specific namespace. The function is now available as `iceberg.system.apply_changelog()` instead of `apply_changelog()`.
  - Improve `ApplyChangelogFunction` by moving it to connector-level functions following the pattern introduced in PR #25594.
- #25882 (Author: Feilong Liu): Add plan support for using uniqueness of row_id
  - Fix add exchange and add local exchange optimizers to simplify query plans using the unique $row_id.
- #25886 (Author: Zac Wen): [native] Expose index join perf related session properties
  - Add property ```native_index_lookup_join_max_prefetch_batches``` which controls the max number of input batches to prefetch to do index lookup ahead. If it is zero, then process one input batch at a time.
  - Add property ```native_index_lookup_join_split_output```. If this is true, then the index join operator might split output for each input batch based on the output batch size control. Otherwise, it tries to produce a single output for each input batch.
  - Add property ```native_unnest_split_output```. If this is true, then the unnest operator might split output for each input batch based on the output batch size control. Otherwise, it produces a single output for each input batch.
- #25910 (Author: adkharat): security(csp): fix ZAP findings — form-action, img-src
  - Fix CSP by adding `form-action 'self'` and setting `img-src 'self'` in response to `CWE-693 <https://cwe.mitre.org/data/definitions/693.html>`_. :pr:`25910`.
- #25918 (Author: Nishitha-Bhaskaran): Upgrade org.objenesis:objenesis dependency version
  - Upgrade objenesis version  to 3.4  in response to the use of an outdated version.
- #25919 (Author: Pratik Joseph Dabre): [native] Validate sidecar function signatures against plugin loaded function signatures at startup
  - Update coordinator behaviour to validate sidecar function signatures against plugin loaded function signatures at startup.
- #25924 (Author: dnskr): Generalize the doc page explaining how to deploy Presto with Homebrew
  - Improve the doc page explaining how to deploy Presto with Homebrew.
- #25931 (Author: Sumi Mathew): Upgrade org.reflections version
  - Upgrade org.reflections to 0.10.2 in response to the use of an outdated version.
- #25951 (Author: Mahadevuni Naveen Kumar): Implement Iceberg system.bucket scalar function
  - Add Iceberg bucket scalar function.
- #25984 (Author: Pratik Joseph Dabre): Split Provisio plugin packaging into plugins and native-plugins directory
  - Update Provisio packaging to split plugin packaging into plugins and native-plugins directory.
- #25985 (Author: Jalpreet Singh Nanda (:imjalpreet)): Update `current_time` and `localtime` DateTimeFunctions to align with the session date/time
  - Fix `localtime` and `current_time` in legacy timestamp semantics.
- #25990 (Author: Sumi Mathew): Upgrade org.antlr version
  - Upgrade org.antlr version to 4.13.2  in response to the use of an outdated version.
- #25991 (Author: Nishitha-Bhaskaran): Upgrade org.fusesource.jansi:jansi version to 2.4.2
  - Upgrade org.fusesource.jansi:jansi version to 2.4.2  in response to the use of an outdated version.
- #25999 (Author: beinan): Bump up iceberg version to 1.8.1
  - Upgrade Iceberg version to 1.8.1.
- #26003 (Author: Pratik Joseph Dabre): [native] Add parameterized varchar type in the list of supported types in NativeTypeManager
  - Add parameterized varchar type in the list of supported types in NativeTypeManager.
- #26006 (Author: Shahim Sharafudeen): Upgrade netty to 4.1.126.Final to address CVEs
  - Upgrade Netty to version 4.1.126.Final to address 'CVE-2025-58056  <https://github.com/advisories/GHSA-fghv-69vj-qj49>' and 'CVE-2025-58057  <https://github.com/advisories/GHSA-3p8m-j85q-pgmj>' _.
- #26007 (Author: Sumi Mathew): Upgrade scala-library version
  - Upgrade org.scala-lang:scala-library version to 2.13.16  in response to the use of an outdated version.
- #26019 (Author: Nishitha-Bhaskaran): Upgrade org.apache.yetus:audience-annotations version to 0.15.1
  - Upgrade org.apache.yetus:audience-annotations version to 0.15.1 in response to the use of an outdated version.
- #26021 (Author: Dilli-Babu-Godari): Bump jdbi-core and jdbi-sqlclient to latest version
  - Upgrade jdbi3-core:3.4.0 to 3.49.0 and jdbi3-sqlobject:3.4.0 to 3.49.0 in response to the use of an outdated version.
- #26024 (Author: Dilli-Babu-Godari): Bump org.glassfish.jaxb:jaxb-runtime jar to latest version
  - Upgrade jaxb-runtime to v4.0.5 in response to CVE-2020-15250.
- #26025 (Author: Pratik Joseph Dabre): Add presto-sql-helpers directory for inlined SQL invoked function plugins with plugin loading rules
  - Add `presto-sql-helpers` directory for inlined SQL invoked function plugins with plugin loading rules.
- #26044 (Author: Pratik Joseph Dabre): Package memory connector plugin under native-plugin/ using Provisio
  - Update Provisio plugin to package memory connector plugin under native-plugin/.
- #26054 (Author: Kevin Tang): Presto add sqlText to accessControlContext
  - Add sqlText to SessionContext to be used by system access control APIs.

# All Commits
- 0325368a21b4f6b9c6220575ac1a4b90a3eb71a2 Add a check for CVEs present in new transitive dependencies (Timothy Meehan)
- de0fe1cc6decc897c358458a08eecdbcb19951aa [native] Pass extra_credential into QueryConfig (#26058) (Ke Wang)
- 18b7e337a07d5f5ee16beced8f96e5339a3e97bb [pos] Fix broadcast related tests (Jialiang Tan)
- 105af44c06912acb619373507a008950eabefdd8 [pos] Fix connector caused test failures (Jialiang Tan)
- 6fe5a5dcc6dad9e9a9e62e22f60db6cace56511a Add GitHub Actions workflow for dependency review (Timothy Meehan)
- 5561e0a9dc924026a724a8a3001d27831d5f693e Initialize server port when initializing the test class instead of constructor (Elbin Pallimalil)
- 48bd9f817fd269206cf975be51cc551581982595 Add ability to schedule splits based on Task load, not Node load. (Sergey Pershin)
- 3829cb97ddcacc7f441f5a49b1f4cce1efd4a852 [pos] Fix java.lang.NoSuchMethodError: java.util.Optional.orElseThrow() (Jialiang Tan)
- 5adcd27a9b881c374e0ea307cfa1fc5ea5bbc58e Presto add sqlText to accessControlContext (#26054) (Kevin Tang)
- bc7ac8f88d67290b1e5acacc8bb863e3b48436f9 Include native built in functions ci test (#26056) (Kevin Tang)
- e9605429708254adc82abc7658947f8021feef3e Fix flakytest in Clickhouse CI (Nishitha-Bhaskaran)
- e840f097eafa4bd5e56ed0069317c557abd7f702 Include native build for prestocpp-linux-presto-on-spark-e2e-tests (Reetika Agrawal)
- ef6887aaef431cf23e2b02507cfd2b741ba964db Correct session property details in release notes (Reetika Agrawal)
- a1f44c145cae7cc38859570d8008fa2f1950b966 Add `AuthenticatorNotApplicableException` in presto-spi (Jalpreet Singh Nanda (:imjalpreet))
- b0f44f0a7b16efcb749f52c8e444396b59db4cf1 Alternative URL for gperf (Karthikeyan Natarajan)
- 6469ea3edee9d4481b429509248f09e130da49eb [native] feat: pass source and schema to connector config (Vivian Hsu)
- 18f145dce05c46bef41a95b86742eecd0ab4a4f1 [native] Remove deprecated function signature (Zac Wen)
- 859f0206e54b98b23e9748d4759ba8b38e710c2f [Native]Remove redundant loops and unnecessary task launches (wangd)
- a02f2bc2ef029f2d6723c4b4ddb6cf9f3de16019 Add presto-sql-helpers directory for inlined SQL invoked function plugins with plugin loading rules (Pratik Joseph Dabre)
- f0d1ce045f5f233217fbba99c1028f3c65fee88c Add ThriftFilterPushdown for native execution (Zac Wen)
- 68280190528a13c47e75425763a155334c6713e6 Upgrade scala-library version (Sumi Mathew)
- 4bacb8efa69f7c94038bbe7650a416a448f0f30f Enable case-sensitive-name-matching support for clickhouse connector (Nishitha-Bhaskaran)
- d7bbf5db218355429c5118063e4279490a1cb4b8 Enable Clickhouse CI tests along with fixes (Nishitha-Bhaskaran)
- 80095e95e36307df6f8d8e6a977425cef84ba709 Fix aggregate function builtin special functions (Kevin Tang)
- 6ccd887b0bd819b3d77c6bdb2f5b4109c880db43 Add singlenode-kerberos-hdfs-impersonation-with-wire-encryption-cipher-suites profile in product tests (Jalpreet Singh Nanda (:imjalpreet))
- 112397091efa1b990a0897353a467f235e687eb9 Enable PrestoExtendedFileSystemCache Integration Without Reflection (Jalpreet Singh Nanda (:imjalpreet))
- 612ba13e0cb66e3d480b9f880d7c4a4d8c0db2ba Upgrade to Hadoop 3.4.1 with Hive 3 support and test fixes (Jalpreet Singh Nanda (:imjalpreet))
- 7f24bcd5a5c6f98e2c2ee5bf8d226c3119706cfa Workaround for HDFS permission issue (Jalpreet Singh Nanda (:imjalpreet))
- 88cab14ff5ec4b4e494fa766b37674073435de03 Align Tempto with default Hive user configuration (Jalpreet Singh Nanda (:imjalpreet))
- 339ba7962f33fa2754185af52a0091bf42c4f8d7 Force bucketing v1 in hive-tests (Jalpreet Singh Nanda (:imjalpreet))
- 0a5efade2296e85d90b0f982007920eb483b7de9 Fix bucket/split count check in AbstractTestHiveClient (Jalpreet Singh Nanda (:imjalpreet))
- fe4606bd0136448b464344199095dfdfbb7f8076 Add LDAP authentication support for environments without anonymous bind (Jalpreet Singh Nanda (:imjalpreet))
- 0cbc3110e7a8c939694b6927b46bfff8aeaa5f07 Enable and fix all Cassandra connector tests in CI (Shijin)
- 437120918424b4f03ee3b57360bc2eea48d62db0 Bump up org.apache.yetus:audience-annotations version to 0.15.1 (Nishitha-Bhaskaran)
- 41016fee70319839e0b74e894c04bbb2cc75186f [pos] Fix TestPrestoSparkNativeArrayFunctionQueries (Jialiang Tan)
- 0788f73f6c95378261641274d6cd3969d4df5375 [native] Introduce firstTimeReceiveTaskUpdateMs in PrestoTask (Ke Wang)
- 4a1d83f7e90f977a7f9e3f6e29b5063ce78e44a0 Add plan support for using uniqueness of row_id (Feilong Liu)
- 20ed52bb11b202795ab8a8911782ed9a9301fe04 Update security docs to include oauth2 (auden-woolfson)
- 6247d6c5518d01b3a9d4d9b74d2d32cdcf6a3e5f Fix build and test failures from oauth2 w/o CLI (auden-woolfson)
- 398056cde974766aa4b64a9fca03ab8cab151ac6 Tests for the OAuth2 Authentication and OIDC discovery (Anant Aneja)
- 3e1ea50b06d0d9edbfc6e65a5782923791e5e792 Add support for OAuth2 authentication (Anant Aneja)
- 498ba83378b9bb91d274a9688280edc79f3c6bdc CLI external authentication and composite redirect handler (Anant Aneja)
- 877721081036a4562017008f7844170faf7f040f External auth support for presto-jdbc and presto-client (Anant Aneja)
- ed6e4a990dea4d627c034e1c378af3ff872f4107 Plan table function invocation and add tests (mohsaka)
- de552585313abee4e4f5a055d57628b1bd5ec2ed [native] Add protocol support for non-index-lookup-join-condition (Zac Wen)
- 04a4819d6c8cf13620884aea9fa1c1203f1c2f3c Upgrade Hudi version in Presto-hudi module to 1.0.2 (Vamsi Karnika)
- 22b74613dc076c3081c0437e6ca3f142c336ab50 Enhance lineage capture to include column-level details (Nidhin Varghese)
- 8eea8b78fa88dfe8c8b1939ca228cf771bd9160f Bump org.glassfish.jaxb:jaxb-runtime jar to latest version (Dilli-Babu-Godari)
- abad3add7684bfd65bd2648776cf13fdddd648ff Bump jdbi-core and jdbi-sqlclient to latest version (Dilli-Babu-Godari)
- d23167db6f8fa53ffaf427c3d7c594b412f5c9d2 Add array_sort() and array_sort_desc() with lambda support for key extraction (Dilli-Babu-Godari)
- 0494998b3888fd858f30962803aeca2e6e0bc093 Package memory connector plugin under native-plugin/ using Provisio (Pratik Joseph Dabre)
- 4261dcf3e33b2685419690a692e45c686a3fed74 Enable more features for prestissimo image (#25712) (Li Zhou)
- 8f96415095e4c9b90802306e88df1975bd8ac628 Upgrade org.fusesource.jansi:jansi version to 2.4.2 (Nishitha-Bhaskaran)
- 003cda687413b5d9be451165a36af7e7aea6970c [native] Assign createFinishTimeMs at point of task completion in prestoTask (Ke Wang)
- 95215807d26610abf277abb1850297153313300b [sapphire-velox]fix: Fix to handle multiple TaskSource have the same source node (#26031) (Xiaoxuan Meng)
- 4865fc95b6d29af18c7e009200e4462ac4d605c2 feat(connector): Add mTLS support for Arrow Flight (haneel-kumar)
- 39ea2c08aa1da956a0f41a1874283aa501f394cd [pos][native] Disable failing presto-on-spark native tests (Shrinidhi Joshi)
- a37b4452547ac5b134cddbd8bf0ecab0b2f50a2d [pos][native] Add presto-on-spark native tests step to Github CI on PRs (Shrinidhi Joshi)
- 0a029e742f5d8dc1d551545dc63bc275c8722fef [pos][native] Unit testing fixes (Shrinidhi Joshi)
- d7193c7ee7c83687de11cf85e45d45e714e553d2 Bump up iceberg version to 1.8.1 (beinan)
- 809ae7bcfb6581a4d36bc4fca833c5d9944caad1 [native] Disable Velox mono-library build (Christian Zentgraf)
- 0bdb471a9893d10d68abdf2a2268013c8b51988f [native] Advance velox (Amit Dutta)
- f31246e1ecce7cc1ea6b2fff34a0dc701fa9c5a9 enhance csp security with form-action directive and stricter img-src (adkharat)
- 6b5dbf80c57426039979c2ad41fae3674277ab89 Upgrade org.antlr version (Sumi Mathew)
- 1fc6b0c2154751a1c7f2cb7c719326c81b3f5c34 [native] Add parameterized varchar type in the list of supported types in NativeTypeManager (Pratik Joseph Dabre)
- d5abf92ed89fb82a5ddf664aafaa9e36f158173a Upgrade org.reflections version (Sumi Mathew)
- 6732f41193932b2bc3ef69cff26939f78b869c4a [native] Add runtime stats taskCreationTime (Ke Wang)
- 493639063b0f5d7bcc570dbabb448b33fcc70093 Split Provisio plugin packaging into plugins and native-plugins directory (Pratik Joseph Dabre)
- 987c02f809c96b669bb1143f2d7c4de754ddf435 [pos][native] Setup cpp worker memory settings based on sparkConf (for smart retries) (Shrinidhi Joshi)
- eaf1d283ba2fbfe91d383ab118031390265c4026 Allow duplicate function signatures when matching with generic candidates (Pramod Satya)
- e366be17187e5396ae0c96dceffa21b586410ae4 [presto] Add enum type flag to Prestissimo worker config (#25989) (HeidiHan0000)
- 07a1a884e62ea2499410499ea0b67871b34ec1ca Upgrade netty to 4.1.126.Final to address CVE-2025-58056 and CVE-2025-58057 (Shahim Sharafudeen)
- 197a26b61193688adc7f8ca26e74791bee47ca67 visitEnumLiteral fix (abhinavmuk04)
- eab926355537063fd5838015a0d55b89e4a51142 [Coordinator throttling] Scheduling Policies for Admission Control based on worker load  (#25689) (PRASHANT GOLASH)
- 29b16570633670287c9954a1ffc0c2bd4f3b123a [native] Pass Presto build options to Velox build options directly (Christian Zentgraf)
- b49b416ec0ab4b94cd19535a1670f1feec081e64 Make all in-tree connectors utilize new SPI method in ConnectorMetadata (wangd)
- 7a209483caadf1a90f3ac43c4e2cbd662489e9ce feat: Add SpatialJoinNode to presto_protocol (James Gill)
- 3425c7ef6e8c7b0390d22da7c386c1221ee495ca Fix `localtime` handling for legacy timestamp semantics (Jalpreet Singh Nanda (:imjalpreet))
- 8828a3bfc7ca4a1c3c5178af063eee9f73213fba Fix `current_time` handling for legacy timestamp semantics (Jalpreet Singh Nanda (:imjalpreet))
- 814cdd63d28c292da2a899701fedceb467e36683 [Native]Fix typo in NativeSidecarPluginQueryRunner configuration (wangd)
- 5b391d836dd52a46b6b05bc33cba3b848938c4d6 Fix NullPointerException when catalogSessionProperties is not configured (Jalpreet Singh Nanda (:imjalpreet))
- 6d36242049e4ed124e813760004fcc57a183bdcd Make POS count failed task info and perform dedup on them (Jialiang Tan)
- c9df88d3cfb5c9c7c003bb93a318e543eed209bb Update 0.294 release notes about executable jars (#25982) (Li Zhou)
- a642598233b2294e2b45c366c2e438c06470f35a Upgrade mongo server version (sumi-mathew)
- ba13f42f298a93411e2618aa719f643ee268b539 Upgrade objenesis version to 3.4 (Nishitha-Bhaskaran)
- 7b9613fc1135d562ef513a1f71ca34f310c3e4ee [native] Advance velox (Amit Dutta)
- 4c543a03ba96fa06dd60b7fcfb1e071d54262933 Analyze table function invocation (mohsaka)
- b6c6cbf2d591b96aff67ab5f54c80712b522c516 [native] Introduce presto-native-sql-invoked-functions-plugin for sidecar enabled clusters (Pratik Joseph Dabre)
- 551500e4f6c2f030c0be0c437e6a8b11d344a994 Implement Iceberg system.bucket scalar function (Mahadevuni Naveen Kumar)
- 3257215cfe2ff4ab22329c7e2827a10a8f11b4e8 [native] Use subscript operator to retrieve function handle (Pramod Satya)
- 0d75bc32e4d8943c626502db3d7195bf67124fe4 Remove register-test-functions from PrestoSparkNativeQueryRunnerUtils (Xin Zhang)
- 8c7f2a8487683d73f64b5c765ff073e85dee8fbf [presto] Move out M2Y from RegressionState for regr_slope and regr_intercept functions (#25475) (#25748) (Artem Selishchev)
- 9c5004f0a4ed6de3727696a431583a7294dc28ba Fix up conditional inclusion of Spark2/3 modules (Gary Helmling)
- 92a8ae51ae69e99904605456edd602d43a46ab35 CODEOWNERS: Expand codeownership of presto-spark owners to include presto-spark code in presto-native-execution module (Shrinidhi Joshi)
- 04a922fd9b3848012fa15d759a5fd1f3d0e0a015 [native] README: fixed a typo in aws dep install command. (#25878) (Prashant Sharma)
- e7f7e26a327e3107d9cbf48a7f54c21b9af09af8 Add node selection strategy documentation (Steve Burnett)
- 55df18542c710de6f9cb32a6c19cbc5f828489f8 Add documentation to run native worker with sidecar (Joe Abraham)
- dbc36d3758ba0d3d7ab6462b68ba0a03875f1f3e Add native index join perf related session properties (Zac Wen)
- 686d1c5253927a8adc79685164d87e8ace9009a3 Support multiple catalogs for Presto spark native execution (#25943) (Pradeep Vaka)
- 00f3749103af7b70e8541847342b09de17e185fb [presto] Fixing the Writer count from the system config (#25941) (Abhash Jain)
- 2535ff424d0dd01590eb118578cf0f70d676acb7 Split presto-session-property-managers module (Hazmi)
- 8cf71c16b61523ed04281fbab37717990a389c94 Add a DB based session property manager (Hazmi)
- 8c8e940c1ebdf3f066b70387aff6ffed27181b6c [Native]Remove redundant parentheses in PrestoToVeloxQueryPlan.cpp (wangd)
- 76cac253f04f7f03492c7c22d65dae920e3df753 [Native]Fix typo in PrestoServer.h and IcebergOutputTableHandle.hpp.inc (wangd)
- b89a041322c972c98efd3b09d720699f20915362 Move annotation LiteralParameter to SPI for use in other modules (Mahadevuni Naveen Kumar)
- 6d69b415813b9160a7abd01d4d5603fd1deeac9c refactor: TypeParser to use velox/.../prestosql/...TypeParser (#25877) (HeidiHan0000)
- 27280fcab433068bb6d028c1e98bd27822120cb2 Extract all inlined sql invoked functions into a new plugin presto-sql-invoked-functions-plugin (Pratik Joseph Dabre)
- 4cf74fc3469bae5b8e0ad3a9e6a42006074434b7 Generalize the doc page explaining how to deploy Presto with Homebrew (dnskr)
- a5256abcdb323644c61c3550dc2d0d33a5b59a5d [native] Validate sidecar function signatures against plugin loaded function signatures at startup (Pratik Joseph Dabre)
- 977cabec66c7fb80ca750e7adb8430d4d75ea4d6 Enable copy button feature explicitly (dnskr)
- b7609053da6a38336a1107d4339fdfe138a77672 Fix minor documentation issues (dnskr)
- 9da619b91d095ef590d70a59aec12e4a3182203f Enable case-senstive identifer support for Mongodb connector (Reetika Agrawal)
- 591e49f44732266c53b1a08a96201208df45f7be Enable and fix all Mongodb connector tests in CI (Reetika Agrawal)
- 0b66c1eb55870dc029357646b7bfd73cfab97304 Add `connector_name` to `metadata.catalogs` table (pratyakshsharma)
- b4bb7ce53ee48e8e1bbaeb831fc38121884164ba [native] Advance velox (Amit Dutta)
- 3b32df2e726d1f7cc1470d8394e9db1cf93e8c89 fix: Deserialized TDigest NaN checks (#25907) (Natasha Sehgal)
- ecf13445359ffba74b0650a8ddfe0fb5d4e40e8c [native] Advance velox (Pramod Satya)
- 7357711dc6433de2f627656171a6c3dce262abbf [native] fix: Fail the query if the aggregation stats node fails the sanity check (Xiaoxuan Meng)
- 915f96a492339f11c1f07d2d4352f8e6335dd988 Add output stats for pos sink operators (#25915) (Jialiang Tan)
- 638736888560d5bbaecc34fa774e517238c39881 [docs] Add doc for Type Mapping to connector/deltalake.rst #25357 (Rebecca Whitworth)
- b323a87deb81b37f5f8c394de6f01ad8e8d11266 Exclude executable jars from maven publishing (#25909) (Li Zhou)
- 366daeeb4ac89a5b5639f072b6118f7533a645d2 Enable case-sensitive identifier support for BigQuery connector (adkharat)
- acb54223da11722fdd9eeec08d18f78deab791dc [native] Advance velox (Pramod Satya)
- ac1f4f7b57e4761e328064bd9d21f79e15a7155d feat: Add session property for debugMemoryPoolWarnThresholdBytes (#25750) (Artem Selishchev)
- bcfdd43a3eb86c4a366cc47a14b6059ab3dd169a Fix codeowners file for presto-main/presto-main-base (Rebecca Schlussel)
- daff2fe625434eecd1f8abbb8cd12263123290cf Add Prestissimo committers as codeowners for native session properties (Rebecca Schlussel)
- 6cda0e6bec22ecd8c321bcc6e7f3238825cf5e51 [native] Build for Gcc14 (#25861) (pratik.pugalia@gmail.com)
- 688d4013a28a2eb824ac02ad091ffd0f25b95604 Native built in namespace manager (#25826) (Kevin Tang)
- f3907c8b1a34b0d223f74624676ed9b4c6ae1a3c Resolve map(varchar, json) canonicalization bug (Hazmi)
- 024d57a248da3e91bd69c4462d573b296a1e610d Added `iceberg.engine.hive.lock-enabled` configuration (Hazmi)
- 1d61f3eedcc69ed213b0fda297d44341560acbf4 Add TIME, TIME_WITH_TIMEZONE, TIMESTAMP_WITH_TIME_ZONE to standard jdbc write mappings (Hazmi)
- 44cdb14f683183f25de005f7e7486f7b51db5335 Added DecimalType WriteMapping to QueryBuilder (Hazmi)
- b553f71021f32ef5b266725e331a9e4eacedff4c [native] Return false for queries with spherical geometry in sidecar enabled clusters (Pratik Joseph Dabre)
- 410bb8cbe3049ad5409c0d152a009876cfb92488 [Coordinator throttling] Endpoint on Java worker reporting nodestats (#25687) (PRASHANT GOLASH)
- 1cf0190f53ea393406d1215eaa9a6da608cf95ab Add @pdabre12 as module committer (Timothy Meehan)
- e52d33a4514b89ce6d9dfe45c2ea3170242c73b9 Fix maven publish and add executable jars to github release (#25902) (Li Zhou)
- f1f4ced45f44f3468c6e9f207afb0799722d4645 Parse CharN in protocol to Varchar type (Ge Gao)
- 86d223bc83875b08df8065741f0efe3b6f539c57 Add missing content and fix typos in comments (wangd)
- 95fc85e087a1abf34acb238a5046e7342a3a60d8 Fix incorrect session property names (Anant Aneja)
- 27683bf37ab97a42433ca39270a137194fe64468 [native] Refactor arrow flight build in adapters script (Christian Zentgraf)
- fd534ddf3b37598c2ca20847fa9ea3b97bed7084 Fix bug in http message body extraction (Nikhil Collooru)
- c82e52f25e41aee76e29f0d81ad644bdda8fd771 Enhance test framework to handle start/rollback/commit in a nature way (wangd)
- b016faf6cd8c1d3e5a75729d9eddb1ccc08ba209 Refactor test framework to return transactionId control flags to client (wangd)
- 3b6bec0d0035f19bb846bef478b0c981daae25ba Add session property to toggle Orc use column names feature (aspegren_david)
- 0c7260016f494d768b5d24da3934ae421ac7baf3 feat(OSS Presto): Support tracking Page Sink Runtime Stats in TableWriterOperator (#25846) (Matt Karrmann)
- 8bf4ab167cbac8f3a26c2df559124d78f363917a [native][pos] Make system config free form (Jialiang Tan)
- 664e0e5325ecd570df1bf8823279f78d3e0c49cd [native] Expose index join perf related session properties (Zac Wen)
- 52afa5ab5176c37bb7cd555db8395fc9b85ff39c Add performance warning for MAP_FILTER (abhinavmuk04)
- 8ac104684c2cd667701de4d27d25bb6513c2fb3d Deploy jar individually to avoid 413 error (#25879) (Li Zhou)
- 0a49b00734a2a7ffb82e94aac627192ca2c338f4 Migrate Iceberg ApplyChangeLog to connector function (Amritanshu Darbari)
- 604587b5eb36dee333eaf0cd397ce7d636ed315b Extract SQL invoked inlined functions tests into AbstractTestEngineOnlyQueries (Pratik Joseph Dabre)
- b1c7bc4c9b5618e38783279d622033cfc1b981eb [Iceberg]Support specifying multiple transforms when adding a column (wangd)
- 29c18a3a5d848e66ca7cd029854cf4b5fcf2de95 Enhance property mechanism to support specifying multiple value types (wangd)
- e53f403c6459c8f2b1b4c6e9ab5c2c0d4392ca94 [native] Advance velox (Amit Dutta)
- 5bfedcea32a87e1844810aa491f90169970f349c [native] Advance Velox (aditi-pandit)
- a8bc182dace50a0758de671c8ed1d3a228ffa294 Clean up InternalPlanVisitor (#25867) (Natasha Sehgal)
- 9b882ab71d4bfc8c0d16395e138a40b26ba55f8e [native] Make config text-writer-enabled true by default (Ke Wang)
- 44c99e7491e6361d3bd8db1c5068c1f71ceba2ca [native] Enable TaskUpdateRequest thrift serde in QueryRunner (#25857) (vhsu14)
- 61f62268fa4e002c99d2583f9a1542dabd8397c3 refactor: Rename SpatialJoinNode.Type -> SpatialJoinNode.SpatialJoinType (James Gill)
- 59d13b0dd24fb32c92b170d2bc1198fb2e842d2b [native] Fix using ccache for macOS CI (Christian Zentgraf)
- c7a444c62a5c7ea8de898a93a45b2b27bcd2e05c Add SPI support for TableFunctions (mohsaka)
- 9548cafc0df597d92402de247a134a109e61f314 Always evaluate built-in functions using the presto.default namespace (Tim Meehan)
- 88ba01c47d9cb1aaeb447c69c63ce5ddcf49d385 Migrate evaluateConstantRowExpression to ExpressionOptimizer (Tim Meehan)
- 02ee89f888caa9242104b8190dca7b3641649d5b [native] Remove velox properties from ContainerQueryRunner (Joe Abraham)
- 7b06b7b8d2dd1a7ab9244f58c83c0825ce921954 Upgrade mongodb java driver from 3.6.0 to 3.12.14 (mehradpk)
- 365b4cc7bdc82ae400cc1effc907edf9c9128d54 Remove unused TestGroups from presto-product-tests (Jalpreet Singh Nanda (:imjalpreet))
- 4a04a11981d5f2a51de2729bb1947ae68bc766f2 Enhance ShowColumns (Sumi Mathew)
- 01fe2c82a73ce4bceece055f1dae09acacf5b37a [native] Make stuck driver detach worker threshold hardware based (#25855) (Jialiang Tan)
- 659b5a1b553b7a0e519aab4a021ec3ace134260e Fix rename column failed if the column is used as source column ofnon-identity transform (Ping Liu)
- e3471ee38415b1a0bfa077128576954569c871cb Update presto-docs/src/main/sphinx/admin/properties-session.rst (Rebecca Whitworth)
- 307bba09d80d3f1a4f89f766fbdf767b13c7ca7c #25651 [docs] Add doc for pushdown_subfields_for_map_functions session property (Rebecca Whitworth)
- 2bc42ae83d7ca43c6c585a61e06637139a2d6cf0 [native] Add arrow flight unit tests to CI (Christian Zentgraf)
- 788e028b2c92003f007e6145f225384ce5f1b7eb Instrument native worker config from spark query runner to injector factory (Jialiang Tan)
- ed513883a2fceacfaad4a87c223c0ec74f20fb7b Add proper checks to handle cases where SchemaTablePrefix schemaName is null (Bryan Cutler)
- 429c6a814c2d521cabebe4772764c966105ff3ea [native] Support using custom storage access username based on source and client tags (#25827) (vhsu14)
- a40ff0d555152ab20397f7800caa77a6bec6fde8 Support building presto on spark to support spark3 and spark2 (Kewen Wang)
- 0dd6fc4ddd10681b774a037861d207a071d9dc5f [native] Advance velox (Amit Dutta)
- b159e46a5c97ce4288669d5587ce74470b5a9c59 Add support for retrying on a different cluster (Tim Meehan)
- ca0c7e5697839d450e2feddf3b02eb1eff73b98e Correct session property rules json (pratyakshsharma)
- 62226d50180a287db5e32192480d4395faf41494 Support BuiltInFunctionKind enum parameter in BuiltInFunctionHandle's JSON constructor creator (Pratik Joseph Dabre)
- f911cc8e4b8cc4558aec7fa0df73fef4d534dc00 [docs] Add native sidecar plugin documentation (Pratik Joseph Dabre)
- 3aed57ff09bca282bd9c08abf0d32bf81b5f0e7c Implement visitMetadataDelete in Planner Optimizations (#25745) (Natasha Sehgal)
- 938ccf69e559ad1bf65e42b955a047370dcf74eb migrate to AWS SDK v2 with MinIO compatibility fixes (Sayari Mukherjee)
- 9d6d6e192f651049d95c82efc23b49a13d2cd6f5 Add support for the MariaDb driver to the function namespace manager (Anant Aneja)
- 3fe0b457da4bd705b8f42b88f41a24c684d3d995 Handle special characters in column names and subfields (Naveen Nitturu)
- af4fc61c70d6252c7297a1d35b45d48949af8070 Implement support for connector specific builtin functions (Mahadevuni Naveen Kumar)
- 2b59d2371cf2bafbeb4ed1dbb30965dbdfcc7dc8 Support enforcement of NOT NULL column declarations (Anant Aneja)
- ff042d84259b5465df60ec8666c6c14dd467e214 Fix output variable alignment in ExtractSystemTableFilterRuleSet (Tim Meehan)
- 89ab91535147c53fe18d11bb1b28773440071396 Print IndexSourceNode table layout in query plan (Zac Wen)
- c6d8c01f831cea76e9bef4059627719b65abac74 [native] Make presto-on-spark native config up-to-date (Jialiang Tan)
- 1bf61944a28732cd904d5be3dd84a8bfd4889fca [native] Remove BaseVeloxQueryConfig (#25758) (Jialiang Tan)
- 02a06224e8cb51ad83751557f26da981bab21362 Relax filter constrain for index join planning (Zac Wen)
- c83e6e5f4504fd836adfb5967b1b11294c18b9e7 fix for bigquery select not working (adkharat)
- 754791a9b7b463f2dd6452cf2728907d2c9cba38 Fix Query ID tooltip position in Web UI (yangbin09)
- ca49aa027999447b7aaf50e76aa359ff8acd8cff [native] Ensure calling 'no more splits' after the task started. (Sergey Pershin)
- a5243a17daa9bc3c4cf93892071c4994476133f7 fix: NumericHistogram handle NaN cases (#25793) (Ke Wang)
- 6b104005bfcd8cc5893c8a96f8c2312460e3f20c Exclude ValidationMessages.properties from shaded presto-jdbc (Rebecca Schlussel)
- 2cec1cd6fbbfb9ece165cc7d5bc9613f1536b5be [native] Enable Parquet and Spatial by default (Christian Zentgraf)
- f5f0bb70c823669e0ff82a4f68c475432759e3be [pos][native] Use okhttp instead of airlift.http in pos native (Shrinidhi Joshi)
- 16e42ab67563e7ce8dc30410ffc488b1b3aa46de Upgrade netty to 4.1.124.Final to address CVE-2025-55163 (Shahim Sharafudeen)
- 956978a25a1fef59e41b8e2f93c02ac34a7774f0 Support table function invocation in grammar and AST (mohsaka)
- 85e87a29ba0f2ca23502c75a3e1040327a8dc1c6 Remove `invalidate_metastore_cache` procedure from iceberg (pratyakshsharma)
- 9d8354ad9735e7442412b7e5a131bac520d09043 Upgrade Iceberg version to 1.6.1 (wangd)
- e00eeca42eb38a72f1298e9062ea3beb81a48950 [native] Add protocol support for index join constant equal condition (Zac Wen)
- e7420aee0e3d2096d4c91261396df1943b09a82b [native] Advance Velox (Zac Wen)
- 17aa98cf9c877ae28c12b5eee9eb656edbfee72e [codemod] Del redundant-static-def in github/presto-trunk/presto-native-execution/presto_cpp/external/json/nlohmann/json.hpp +1 (#25732) (Richard Barnes)
- bcf32f3cf01580d41cbe14fb035fc444f7e2a9d9 Allow constant equal condition for index join (Zac Wen)
- 55188eb63e1e22544a82f575aa3abfd5a1b71e70 [native] Advance velox (Amit Dutta)
- 4b30a676950c8e3424f418dbda5b32670325f733 Add return in deleteTask (Nikhil Collooru)
- 28380cb5f2c23541cf600d8318d37192541d6ba2 [native] Refactor and cleanup presto configs (#25755) (Jialiang Tan)
- 4a71fed10bf38865cc54ddadf4ae05e272a692c7 Add tests for getSqlInvokedFunctions() SPI (Pratik Joseph Dabre)
- cd537401efc18f3743416927fdb9152fdc4de5d8 Introduce getSqlInvokedFunctions SPI and BuiltInPluginFunctionNamespaceManager for registering sql invoked functions (Pratik Joseph Dabre)
- 1e025e6e79d36156f1f22b012d4f881299a2c899 Upgrade reactor-netty-http to 1.2.8 to address CVE-2025-22227 (Shahim Sharafudeen)
- 05a28cea0009f402b64d19838c603ae3801d61b6 Ignore unknown table formats when querying system.jdbc.columns table (Jalpreet Singh Nanda (:imjalpreet))
- f2ec6adb8a489ca5f40d2ef0d49b0c53712c02a0 Update invalidate cache docs for hive connector (pratyakshsharma)
- 06550006c845432eb35579a8ec96a506b55dfca1 Cancel duplicate checks release notes actions (Christian Zentgraf)
- 5c36ee5a982dcbe3a4ede6035dcfefa415cf1c2c Add planner support to prevent mixed CPP/Java execution (Tim Meehan)
- 3d3f541e7e823f83de2afaff4fe9273dda62175b docs: update README with Java 17 run flags for running Presto in IntelliJ (Jalpreet Singh Nanda (:imjalpreet))
- dec4e72762cec392d24dab3f5727837df8e8e1a3 Fix formatting in admin/properties.rst (Steve Burnett)
- 6500aca6d538e13c489bdb6fa5069be3201b0699 Update doc about sort order transforms in connector/iceberg.rst (Steve Burnett)
- 2524b316463cda27d75ca701f5e2793ee28b4b91 Add batching support for PreparedStatement (pratyakshsharma)
- f3c6b7ce9ba2ea7f77e3232e501c879597e02fa3 [native] Fix CentOS adapter install in dependency image (Christian Zentgraf)
- 665e694bf1f228a2df5555cf533f041c098de8ed use has_value instead of hasValue (Valery Mironov)
- b299e9fe0f20783b7242d257956087930c3d15f0 Update Configs.h (Valery Mironov)
- c8f154f74883a17eb81d5a0cd4d595735287ba9a docs: add IntelliJ JDK 17 workaround to README (Jalpreet Singh Nanda (:imjalpreet))
- 9b19f4a02ab1b1c13667dbac30f7891fd98757ee Add experimental planner support for sort merge join (Zac Wen)
- 8392ce7025967b93aa02ff9e8160eb01b4881bbc Update ConfigReader.cpp (Valery Mironov)
- 3c526acf11bf1a05beac914d2c5429c63aad75c1 Use TestNG retry to reduce flakiness in probabilistic result validation (wangd)
- e03eff1b10329554af6c58828fb2a39c5204cffe Java 17 and Jetty 12 Upgrade (Zac Blanco)
- a4b4e390943c08bbffa3c73f9d8d541af3cba9ca Update commons-lang3 to 3.18.0 in product-tests to address CVE-2025-48924 (Shahim Sharafudeen)
- c27a5598b53462424591890c4010eb5471577a39 [native] Add native session property binding to presto spark module (Jialiang Tan)
- 43475f47282b946670c2000de7f1254cd483c2c2 [native] Advance velox (Amit Dutta)
- 6687c509da70275a1b0b7e05cf1e14740f2e2c44 Revert "Enrich Update infromation in Queryinfo" (Nidhin Varghese)
- 46cb62874cb2de8c59f067f8920d4cd254892433 Fix server start (pratyakshsharma)
- 43f59c3bd43ce1fb7d6642f02c0acbd0d4b71251 [native] Make SessionProperties global singleton (#25724) (Jialiang Tan)
- 0e7e4e06a5772432a65bf2dbb964c1026ddbaf29 Add unit tests for index join subfields pushdown (Zac Wen)
- 84ae8406623057411a480625910146c818aca43d Remove negative check on several stats. (Sergey Pershin)
- 4f0d345e6e631718c2dc70b5ea73143e7a4223c7 Add read support for geometry and geography data types in postgres connector (Mariam Almesfer)
- 9e3dccfdf00af2d28961545244a043d490237a7b Fix duplicate binding for spark (#25729) (Shang Ma)
- e0d3305589630398b82ecbc689db7e17547f7408 Make http2 communication configurable (Nikhil Collooru)
- 829a79227466beba2d68e4dc96c333ce2147999c [native] Fix session properties race condition (Jialiang Tan)
- b0b8a8ddc6390fc53209f7945436135231df2a45 Add support for ReactorNettyHttpClient (Nikhil Collooru)
- 70e1d5ee9f070606eaaded12aff2c3e4097ee94c RuntimeStatsMetrics Reporter implementation (j-sund)
- 0acd038d97963145c1d635de6e13a6be8288e156 Add support for tuple type in the Cassandra connector (Bryan Cutler)
- ba56db9ba57bd2dcf1473f3069de2b7dc1f618ec Remove duplicate binding (#25701) (Shang Ma)
- f29d1b42b63eb48ccd43ee4f4916147f7b16529b [native] Fix unnecessary include (Ke Wang)
- 59f69c18bb33ae6ab0a857aafaf249be60cf0ca2 [native] Add max-spill-bytes system config (Jialiang Tan)
- 5c7fbf447cf9a513047dfb3a76914765d613b32f bump drift version to 1.46 (Shang Ma)
- 0ba1c089cf69c01f6b5dff37acd440c4a472c678 Fix presto query config kQueryTraceTaskRegExp (#25702) (juwentus1234)
- bc7c50bcdc728ecb8d257e3c821eb1ec4afa3d7c Fix expression queries in unit tests that use TestingConnectorSession (Raaghav Ravishankar)
- 591e3337be27702b5e208cd6ae8620085bf579b6 [native] Add thrift codec for remote split and support for ExecutionWriterTargetUnion (#25595) (vhsu14)
- 977a368ce55ea11ec5e4ddd76e8f619eaab6fb1f [native] Advance velox (Amit Dutta)
- 834af88147332f3641674582c628462073d50c88 [native] Fix incorrect exclusion of PrestoC++ unit tests (Christian Zentgraf)
- 3521acf1d00997f530e3646dd6b3a9de8b373ea0 Fix NPE in IcebergHiveMetadata.getViews when the provided schema is null (Bryan Cutler)
- 75a4e635fa06747b9f5ac2de1cf674e1cb0d0442 Add kQueryTraceNodeId in presto session config (#25684) (Eric Jia)
- 93c482f55bbb4027857bf2d5027f32608684a36c [Native] Register Text Writer (Ke Wang)
- f4fd9837b7e589d4bc17e8f446b9d48719690365 Fix flaky test in `TestHiveCommitHandleOutput` (wangd)
- 0136c7f4315d9eae5b6453e7817118acbbeb7269 Remove unused session property `pushdown_subfields_for_map_subset` (wangd)
- 64661435444c3daa19db8519cf9e437884a540e6 Fix spill config plumbing for pos cpp (Jialiang Tan)
- 3545b1dc8de045b30f72148678fc4628e7503b4f [native] Fix broken unit test due to IndexJoinNode change (#25691) (ericyuliu)
- 91f1529580daf179ac554b3d929b8a5f1c44534c Enhance PushdownSubfields for index join (Zac Wen)
- e625575dc23e92f72fe97581376fea2e68872a41 Normalize tables and views list in MetadataManager. (Reetika Agrawal)
- 4891aaf7ba6e2a63eabe4b83178a171d627c1e44 [native] Make PrestoServer::driverExecutor_ abstract type (Jialiang Tan)
- 2179ba7851754b746c895841625acaa3a61efd7e Add support to provide thrift codec for connector specific fields (#25242) (Shang Ma)
- d652d1d1fd67a5372e1600cf6343936a9566a684 Add support for TLS in Redis Connector (nishithakbhaskaran)
- 7f27481f0d51ea9d66ba4b8152166095cf8f99a6 [native] Advance velox (Amit Dutta)
- 1a6ce9ea7344ef6dc21820d302e082ec2f7c095a [native] Advance velox (Amit Dutta)
- c4ec41565ddad776acf93c813e7e5a81f8efd852 [native] Add PRESTO_ENABLE_SPATIAL option (Christian Zentgraf)
- 736a5da8be25a7f0dea2d0e81699ff3a7c7a7161 [native] Add RestFunctionHandle to presto_protocol serialization (Joe Abraham)
- 5e23026fb58301c80d7fa4a4675536fb453048ae Fix formatting in presto_cpp/properties.rst (Steve Burnett)
- c114770ebdfc313be033f12a12e41f47453a6283 [native] Fix index join type conversion (Zac Wen)
- c862ca4cede2a66adadd8161bf12ad5aa1119330 [native] Update to use C++20 (Christian Zentgraf)
- 383ffa136a8291f1eaa009635868a0972489c88c Add max_serializable_object_size session property (Raaghav Ravishankar)
- 94b04cb21ba737e9d230ab5188802bc0aad0a4aa Display selected values for schema and catalog dropdowns (Joe O'Hallaron)
- 892cbeee30087d0128fa3e63a5dee510a9a0c4f5 Add Cache-Control header to statement endpoints (Andrew Xie)
- c23b87e84fa7226bc3402e916925498740a0b123 Support max queued_time limit (#25589) (Arjun Gupta)
- 72a78aa75855bf2f3793790342a2206aabe9115f Clean up legacy MetaDataUpdater and ConnectorTypeSerde (#25652) (Shang Ma)
- a6d3df154aa66a5f3e542367e5ff1bcc69cab1d6 Preserve quotedness in QualifiedName (Reetika Agrawal)
- 4607f034d0ee6083a274ef0c9cd667abf503771a Update nessie to 0.95.0 (Mariam Almesfer)
- 45c330598f7512d04b381954c46b1115b6adb052 Support native non-equal lookup join planning (Zac Wen)
- 13cd2655e6e19dbc9a7e4a885f2b7c26efa0b651 Check for null schema when querying from system.jdbc.columns (Elbin Pallimalil)
- aa4de13535712ea49b64693ecfa8eb736d6c223a [native] Make initializeThreadPools() virtual (Jialiang Tan)
- 66e4b58d5013a3a9d0ce6535ce51a29b51da1bc1 add local exchange partition buffer size system config (Wei He)
- 22357085f05c368942c51cf51bd487eacbb13b9c [native] Advance Velox (aditi-pandit)